### PR TITLE
docs: spell the product name as OpenCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agent
 ### Spec and plan
 
 Specs and plans live in GitHub Issues. Domain vocabulary lives in `CONTEXT.md`;
-architectural decisions (including verified opencode loader behavior) live in
+architectural decisions (including verified OpenCode loader behavior) live in
 `docs/adr/`. When working on any issue, read the issue, `CONTEXT.md`, and any
 ADRs touching the area first. If a ticket and an ADR disagree, note the
 discrepancy in the ticket.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ Feature: zero-config install via auto-registration from a bundled model snapshot
 
 ## 0.1.2 - 2026-08-15
 
-Fix: tool-call history round-trip and reasoning effort. Live probes against the Command Code API with opencode confirmed the AI SDK v3 shapes differ from what the converters expected:
+Fix: tool-call history round-trip and reasoning effort. Live probes against the Command Code API with OpenCode confirmed the AI SDK v3 shapes differ from what the converters expected:
 
 - Assistant tool-call parts carry arguments under `input`, not `args`/`arguments` — the converter read the legacy fields, so every prior tool call was re-sent with empty `{}` arguments, corrupting multi-turn context.
 - Tool-result outputs use the v3 `{ type: "text" | "error-text" | "json" | "content", ... }` shapes — `resultText` stringified the wrapper, double-encoding results in history. Replaced with `unwrapToolResult`.
-- `reasoning_effort` was silently dropped: opencode passes `providerOptions` namespaced per provider (`{ commandcode: { reasoningEffort } }`), but the model read the top-level keys. Added `resolveProviderReasoning` (namespaced + top-level fallback) so the configured thinking level actually reaches the API.
+- `reasoning_effort` was silently dropped: OpenCode passes `providerOptions` namespaced per provider (`{ commandcode: { reasoningEffort } }`), but the model read the top-level keys. Added `resolveProviderReasoning` (namespaced + top-level fallback) so the configured thinking level actually reaches the API.
 
 Also: remove duplicated README disclaimer; bump `@ai-sdk/provider` to 4.x and `@types/node` to 26.x.
 
@@ -26,9 +26,9 @@ Fix: emit `text-start`/`text-end` and `reasoning-start`/`reasoning-end` stream p
 
 ## 0.1.0 - 2026-08-15
 
-Initial release: Command Code provider + plugin for opencode. Published to npm as `opencode-cmd-provider@0.1.0` (`latest`), tagged `v0.1.0`.
+Initial release: Command Code provider + plugin for OpenCode. Published to npm as `opencode-cmd-provider@0.1.0` (`latest`), tagged `v0.1.0`.
 
-- `createCommandCode(options)` AI SDK provider (LanguageModelV3) + `default` V1 opencode plugin module in one package.
+- `createCommandCode(options)` AI SDK provider (LanguageModelV3) + `default` V1 OpenCode plugin module in one package.
 - `/connect` browser auth flow, `COMMANDCODE_API_KEY` env var, and legacy auth file support (`~/.commandcode/auth.json`, `~/.omp/agent/auth.json`, `~/.pi/agent/auth.json`).
 - Model catalog fetch, parse, and cache with offline fallback; pricing/cost display; image input; reasoning effort.
-- Config-declared `models` map required under `provider.commandcode` until `commandcode` lands in opencode's models.dev catalog.
+- Config-declared `models` map required under `provider.commandcode` until `commandcode` lands in OpenCode's models.dev catalog.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # opencode-cmd-provider
 
-Plugin + provider package that lets opencode use Command Code as a model provider.
+Plugin + provider package that lets OpenCode use Command Code as a model provider.
 
 ## Language
 
@@ -13,7 +13,7 @@ A copy of the model catalog bundled inside the plugin package; the runtime sourc
 _Avoid_: embedded catalog, static catalog, shipped list
 
 **Auto-registration**:
-The plugin making the `commandcode` provider and its models available to opencode without the user declaring them in `opencode.json`.
+The plugin making the `commandcode` provider and its models available to OpenCode without the user declaring them in `opencode.json`.
 _Avoid_: config injection, zero-config, self-registration
 
 **Declared models**:
@@ -29,5 +29,5 @@ A versioned publication of the package: a git tag `vX.Y.Z` matching the `package
 _Avoid_: publish, deploy, ship (when meaning the whole publication)
 
 **Display name**:
-The name shown for a model in opencode's picker: the raw catalog name with the `[CMD]` prefix (`[CMD] Claude Sonnet 5`).
+The name shown for a model in OpenCode's picker: the raw catalog name with the `[CMD]` prefix (`[CMD] Claude Sonnet 5`).
 _Avoid_: label, model name, pretty name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for helping improve `opencode-cmd-provider`.
 
-This is an unofficial Command Code provider and plugin for opencode. Keep changes small, tested, and easy to review.
+This is an unofficial Command Code provider and plugin for OpenCode. Keep changes small, tested, and easy to review.
 
 ## Development setup
 
@@ -36,13 +36,13 @@ For release and npm smoke-test steps, see [RELEASE.md](RELEASE.md).
 
 ## End-to-end test
 
-`test:e2e` runs the real opencode CLI against a mock Command Code server through the built package. It requires `opencode` on `PATH` and is excluded from `npm test`:
+`test:e2e` runs the real OpenCode CLI against a mock Command Code server through the built package. It requires `opencode` on `PATH` and is excluded from `npm test`:
 
 ```sh
 npm run build && npm run test:e2e
 ```
 
-The e2e verifies the plugin loads and auto-registers the Command Code models — the fixture declares no provider and no models, so discovery proves auto-registration — then attempts a headless `opencode run`. If the headless run hangs before sending a request against a local/mock baseURL — an upstream opencode bug (see the test file for issue links) — the test logs the blocker and skips gracefully.
+The e2e verifies the plugin loads and auto-registers the Command Code models — the fixture declares no provider and no models, so discovery proves auto-registration — then attempts a headless `opencode run`. If the headless run hangs before sending a request against a local/mock baseURL — an upstream OpenCode bug (see the test file for issue links) — the test logs the blocker and skips gracefully.
 
 ## Pull request guidelines
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![CI](https://github.com/rashidrazak/opencode-cmd-provider/actions/workflows/ci.yml/badge.svg)](https://github.com/rashidrazak/opencode-cmd-provider/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/opencode-cmd-provider)](https://www.npmjs.com/package/opencode-cmd-provider)
 
-A provider and plugin for [opencode](https://opencode.ai) that connects to the [Command Code](https://commandcode.ai) Provider API. This enables you to use ALL Command Code plans — Go, GOAT, Pro, Max 10×, Max 20×, Provider, Team, and Enterprise — with opencode.
+A provider and plugin for [OpenCode](https://opencode.ai) that connects to the [Command Code](https://commandcode.ai) Provider API. This enables you to use ALL Command Code plans — Go, GOAT, Pro, Max 10×, Max 20×, Provider, Team, and Enterprise — with OpenCode.
 
 > **Disclaimer:** This is an unofficial, community-maintained integration. It is not affiliated with, endorsed by, or supported by Command Code. You need your own Command Code account and API key or subscription. Command Code's terms, availability, and pricing apply.
 
 ## Install
 
-Add the package to your opencode configuration:
+Add the package to your OpenCode configuration:
 
 ```jsonc
 // opencode.json
@@ -21,7 +21,7 @@ Add the package to your opencode configuration:
 
 That's it. The plugin bundles a snapshot of the Command Code model catalog and
 auto-registers the `commandcode` provider — npm package, name, API key env var,
-and every model — when opencode loads. No `provider.commandcode` block, no
+and every model — when OpenCode loads. No `provider.commandcode` block, no
 `models` map, no network access needed. All Command Code models appear in
 `/models` with the `[CMD]` display-name prefix (e.g. `[CMD] Claude Sonnet 5`) so
 they aren't confused with same-named models from other providers.
@@ -40,7 +40,7 @@ missing:
 The catalog snapshot is refreshed at every release; newly published Command
 Code models appear after a plugin update.
 
-Start or reload opencode, then authenticate:
+Start or reload OpenCode, then authenticate:
 
 ```txt
 /connect
@@ -52,7 +52,7 @@ Select **Command Code**, complete the browser flow, and pick a model with `/mode
 
 ### Browser login
 
-Run `/connect` in opencode and select **Command Code**. The browser flow stores the returned credential in opencode's auth store.
+Run `/connect` in OpenCode and select **Command Code**. The browser flow stores the returned credential in OpenCode's auth store.
 
 If automatic transfer from the browser fails, copy the API key shown by Command Code and export it as `COMMANDCODE_API_KEY` (see below).
 
@@ -104,11 +104,11 @@ opencode run --model commandcode/claude-sonnet-5 "hello"
 ## Model discovery and offline behavior
 
 The plugin ships a snapshot of the Command Code model catalog (`src/catalog/snapshot.ts`)
-and auto-registers every model into opencode's config at startup. Model
+and auto-registers every model into OpenCode's config at startup. Model
 availability changes when the package is updated: the snapshot is regenerated
 from the live catalog at every release via `npm run refresh:snapshot`.
 
-Auto-registration adds no network latency to opencode startup — the snapshot is
+Auto-registration adds no network latency to OpenCode startup — the snapshot is
 bundled, and the plugin never contacts the Command Code API to list models. The
 plugin works fully offline; model availability never depends on the catalog
 endpoint being reachable.
@@ -134,13 +134,13 @@ For vision-capable models, image blocks from user messages and tool results are 
 
 ## Pricing display
 
-The Command Code Provider API does not currently include prices in its model catalog. This provider keeps a static table for models with known prices so opencode can display estimated request costs.
+The Command Code Provider API does not currently include prices in its model catalog. This provider keeps a static table for models with known prices so OpenCode can display estimated request costs.
 
-Models missing from that table display zero cost in opencode. This does **not** mean Command Code will bill the request at zero. Check the current [Command Code pricing](https://commandcode.ai/docs/resources/pricing-limits) before relying on the displayed value.
+Models missing from that table display zero cost in OpenCode. This does **not** mean Command Code will bill the request at zero. Check the current [Command Code pricing](https://commandcode.ai/docs/resources/pricing-limits) before relying on the displayed value.
 
 ## Update and remove
 
-Update the installed package, or remove it from the `plugin` array in your `opencode.json` (the auto-registered `provider.commandcode` entry is injected by the plugin, so there is no config block to remove). The npm package is cached under opencode's plugin cache (`~/.cache/opencode/packages/`); remove the cached directory to fully uninstall.
+Update the installed package, or remove it from the `plugin` array in your `opencode.json` (the auto-registered `provider.commandcode` entry is injected by the plugin, so there is no config block to remove). The npm package is cached under OpenCode's plugin cache (`~/.cache/opencode/packages/`); remove the cached directory to fully uninstall.
 
 ## Development
 
@@ -153,7 +153,7 @@ npm test
 npm run format:check
 ```
 
-The headless end-to-end test runs the real opencode CLI against a mock Command Code server through the built package:
+The headless end-to-end test runs the real OpenCode CLI against a mock Command Code server through the built package:
 
 ```sh
 npm run build && npm run test:e2e

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ This project uses npm semver releases.
 Recommended flow:
 
 - publish prereleases with the `next` dist-tag
-- smoke-test the npm package directly in opencode
+- smoke-test the npm package directly in OpenCode
 - publish stable releases with the `latest` dist-tag
 - commit the release on a branch, open a PR, and merge after CI passes
 - tag the stable release on `main` after merge
@@ -41,13 +41,13 @@ Expected:
 - `next` points to the prerelease version
 - `latest` still points to the previous stable version
 
-## Test the npm package in opencode
+## Test the npm package in OpenCode
 
 Always test from npm, not the local checkout.
 
 ### 1. Model discovery smoke test
 
-Build a fixture config that points opencode at the published package and the mock endpoints, then verify the model is discovered:
+Build a fixture config that points OpenCode at the published package and the mock endpoints, then verify the model is discovered:
 
 ```sh
 npm run build
@@ -56,9 +56,9 @@ npm run test:e2e
 
 The e2e writes a throwaway `opencode.json` via `scripts/opencode-fixture.mjs` (plugin only — no declared provider or models) and runs `opencode models` against the built package. Expected: `ok - plugin auto-registers commandcode/claude-sonnet-5 with no declared config`.
 
-### 2. Manual `/connect` + run test with isolated opencode config
+### 2. Manual `/connect` + run test with isolated OpenCode config
 
-Use temporary opencode config and data directories so the test does not touch your real opencode auth:
+Use temporary OpenCode config and data directories so the test does not touch your real OpenCode auth:
 
 ```sh
 export HOME="$(mktemp -d)"
@@ -98,7 +98,7 @@ Expected:
 manual-npm-ok
 ```
 
-### 4. Cleanup isolated opencode config
+### 4. Cleanup isolated OpenCode config
 
 Only run this if these variables were created by the test above:
 

--- a/docs/adr/0001-auto-registration-snapshot.md
+++ b/docs/adr/0001-auto-registration-snapshot.md
@@ -2,23 +2,23 @@
 
 Status: accepted
 
-opencode only fires a plugin's `provider.models` hook for providers present in its
+OpenCode only fires a plugin's `provider.models` hook for providers present in its
 models.dev catalog, and `commandcode` is not in that catalog — so users had to declare
 every model by hand in `opencode.json`, which was the plugin's biggest UX wart. We decided
 to bundle a snapshot of the Command Code model catalog in the package and have the plugin
-inject the whole `provider.commandcode` entry (npm, name, models) into opencode's config
-during the `config` hook, which opencode runs before it parses `config.provider`
-(verified against opencode 1.18.18 source). Users no longer declare anything.
+inject the whole `provider.commandcode` entry (npm, name, models) into OpenCode's config
+during the `config` hook, which OpenCode runs before it parses `config.provider`
+(verified against OpenCode 1.18.18 source). Users no longer declare anything.
 
 ## Considered Options
 
-- **Live catalog fetch on plugin load (pi's approach)** — would delay every opencode
+- **Live catalog fetch on plugin load (pi's approach)** — would delay every OpenCode
   startup, needs a cache, and fails cold. Rejected for simplicity; git history keeps the
   fetch/cache code if live refresh ever returns.
 - **models.dev PR** — would make the `provider.models` hook fire natively, but the
   catalog is not in our control and acceptance is unbounded. Revisit later if it ever
   lands; no code needed then.
-- **opencode v2 catalog-transform API** — can create providers from scratch, but is wired
+- **OpenCode v2 catalog-transform API** — can create providers from scratch, but is wired
   to the new app, not the CLI provider path in 1.18.18. Not usable today.
 
 ## Consequences
@@ -35,5 +35,5 @@ during the `config` hook, which opencode runs before it parses `config.provider`
   marks the provider connected in `/models`.
 - With no opt-out, users control picker clutter via `whitelist`/`blacklist` on a declared
   `provider.commandcode` entry.
-- First-run default model is deterministically `commandcode/gpt-5.6-terra` (opencode's
+- First-run default model is deterministically `commandcode/gpt-5.6-terra` (OpenCode's
   hardcoded priority list + id-desc sort); no provider-scoped default mechanism exists.


### PR DESCRIPTION
Prose references to the product now read OpenCode, per project convention. Kept lowercase where it is a literal: package name (`opencode-cmd-provider`), filenames (`opencode.json`, `scripts/opencode-fixture.mjs`, `~/.cache/opencode/packages/`), CLI invocations (`opencode run`, `opencode models`), the `opencode` binary on PATH, and URLs (opencode.ai).