### PR TITLE
fix(skills): repair release skill symlink target

### DIFF
--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,1 +1,1 @@
-../../.pi/skills/release/SKILL.md
+../../../.pi/skills/release/SKILL.md


### PR DESCRIPTION
The symlink pointed at `../../.pi/skills/release/SKILL.md` from `.opencode/skills/release/`, which resolves to `.opencode/.pi/...` — one level too shallow. Fixed to `../../../.pi/skills/release/SKILL.md` so opencode can read the skill.