### PR TITLE
ci: gate releases on main commit, fail loudly on stale snapshot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
           registry-url: https://registry.npmjs.org
-      - run: npm ci
+
+      - name: Verify tag commit is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" refs/remotes/origin/main; then
+            echo "::error::tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA}, which is not on main. Land the version bump and CHANGELOG entry on main first, then re-tag."
+            exit 1
+          fi
 
       - name: Verify tag matches package.json version
         id: version
@@ -30,28 +39,21 @@ jobs:
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      - run: npm ci
       - run: npm run build
       - run: npm test
 
-      - name: Refresh catalog snapshot, fix the tag if stale
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Refresh catalog snapshot
+        run: npm run refresh:snapshot
+
+      - name: Fail on stale catalog snapshot
         run: |
-          npm run refresh:snapshot
           if git diff --exit-code -- src/catalog/snapshot.ts; then
             echo "snapshot is fresh"
-            exit 0
+          else
+            echo "::error::catalog snapshot is stale. Run 'npm run refresh:snapshot' locally, commit src/catalog/snapshot.ts, land it on main, then re-tag ${GITHUB_REF_NAME}."
+            exit 1
           fi
-          echo "::warning::catalog snapshot is stale; refreshing, committing, and moving the tag"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/catalog/snapshot.ts
-          git commit -m "chore(snapshot): refresh catalog snapshot"
-          git push origin main
-          git tag -f "${GITHUB_REF_NAME}"
-          git push origin "${GITHUB_REF_NAME}" --force
-          echo "::error::snapshot refreshed and ${GITHUB_REF_NAME} moved; the re-triggered release run will publish"
-          exit 1
 
       - name: Extract changelog entry
         id: notes

--- a/.pi/skills/release/SKILL.md
+++ b/.pi/skills/release/SKILL.md
@@ -7,8 +7,8 @@ description: Cut a release of opencode-cmd-provider — bump the version, write 
 
 A **Release** is a versioned publication: a git tag `vX.Y.Z` matching
 `package.json`, a GitHub Release, and an npm publish (see `CONTEXT.md`,
-ADR 0002). The pipeline owns the mechanics; this skill is the pre-tag ritual
-and post-push verification.
+ADRs 0002 and 0003). The pipeline owns the mechanics; this skill is the
+pre-tag ritual and post-push verification.
 
 ## Version choice
 
@@ -24,22 +24,25 @@ and post-push verification.
    `## Unreleased` when it exists). This exact section becomes the GitHub
    Release body; without it the pipeline falls back to generated notes.
 3. **Commit** — conventional style: `chore(release): X.Y.Z`.
-4. **Tag and push**: `git tag vX.Y.Z && git push origin main --tags` — the tag
-   push triggers `release.yml`.
+4. **Land on main** — main is protected (required `test` check, PR review), so
+   open a PR and merge it. The pipeline refuses tags whose commit is not on
+   main; the tag must point at a commit that contains the bump.
+5. **Tag**: `git tag vX.Y.Z && git push origin vX.Y.Z` — the tag push triggers
+   `release.yml`. Push the tag only; main is already up to date.
 
-The catalog snapshot is **not** your job: the pipeline refreshes it and fixes
-the tag if the live catalog drifted (see ADR 0002). Running
+The catalog snapshot is **not** your job: the pipeline refreshes it and fails
+loudly if the live catalog drifted (see ADR 0003). Running
 `npm run refresh:snapshot` locally beforehand is optional — do it if you want
 the diff visible before tagging.
 
 ## What the pipeline does (no action needed)
 
-Asserts tag == `v<package.json.version>` → refreshes the catalog snapshot; if
-stale, commits it, moves the tag, and re-triggers itself (that run fails with
-an explanatory error; the re-triggered run publishes) → build + full test
-suite → OIDC npm publish (trusted publishing, provenance automatic) → GitHub
-Release from the CHANGELOG section. Provenance requires the repository to be
-public.
+Asserts the tag's commit is on `origin/main` → asserts tag ==
+`v<package.json.version>` → build + full test suite → refreshes the catalog
+snapshot and fails with instructions if it drifted (never moving the tag or
+pushing to main itself) → OIDC npm publish (trusted publishing, provenance
+automatic) → GitHub Release from the CHANGELOG section. Provenance requires
+the repository to be public.
 
 ## Verify after push
 
@@ -53,14 +56,15 @@ public.
 
 ## Failure recovery
 
-- **A stale snapshot produces a failed run + a re-triggered run** — that's
-  normal: the first run committed the snapshot and moved the tag; the second
-  run publishes. Verify with the second run's status.
+- **A stale snapshot fails the run** — nothing shipped. Refresh locally
+  (`npm run refresh:snapshot`), commit `src/catalog/snapshot.ts`, land it on
+  main via PR, then re-tag.
 - **Publish fails** — nothing shipped (npm rejects before writing) → fix, then
   `gh run rerun <run-id>`.
 - **Workflow file changes** — if a fix touches `.github/workflows/release.yml`,
   rerunning is not enough: the run executes the workflow from the tag's tree.
   Move the tag (`git push origin :refs/tags/vX.Y.Z`, re-tag at the fixed
   commit, push) so a fresh run uses the new file.
-- **Pre-publish failure** (tests, build, snapshot guard) — fix on main, rerun;
-  no tag movement unless the workflow changed.
+- **Pre-publish failure** (tests, build, snapshot guard) — fix on main via PR,
+  re-tag at the new commit; the old tag's run cannot be salvaged by rerun if
+  the tag commit itself is at fault.

--- a/docs/adr/0003-release-gates.md
+++ b/docs/adr/0003-release-gates.md
@@ -1,0 +1,9 @@
+# Release gates: tagged commit on main, stale snapshot fails loudly
+
+Status: accepted
+
+Supersedes the "re-triggering snapshot refresh" behavior of [ADR 0002](0002-tag-driven-releases.md). The trigger stays: pushing a `vX.Y.Z` tag starts the release pipeline. Two gates now decide whether it may publish.
+
+The tag's commit must be an ancestor of `origin/main`, and the tag must match `package.json` (existing guard). The first gate exists because the pipeline runs on the tag's tree, not on main: without it, tagging an unmerged or stale commit publishes a version whose source never reached main — the version bump and CHANGELOG entry ship while `main` still carries the old version, and the published artifact is not reproducible from the branch. Pushing a tag while the bump is still in review, or tagging an old commit, fails with an explicit error instead of releasing.
+
+A stale catalog snapshot now fails the run loudly instead of self-healing: the previous mechanism committed the snapshot on top of the tag's tree, force-pushed `main`, moved the tag, and re-triggered itself. That is unsafe twice over — the snapshot commit can be based on a tree that is not on main, and moving the tag re-points the release at a tree that was never the published one; additionally, the branch protection rule (required `test` status check) rejects the workflow's push to `main` anyway, so the path could not run. The release run now refreshes the snapshot in place, and if it drifted, fails with instructions to refresh locally, commit, and land the change on main before re-tagging. Consequences: a stale snapshot can neither ship nor be forgotten — the same guarantee as before, delivered by a loud failure instead of a silent tag move. The ritual becomes: bump + CHANGELOG, land on main via PR, then tag.


### PR DESCRIPTION
Fixes the release flow so a tag push can no longer publish from an unmerged tree or move tags/push to main.

- New gate: the tag's commit must be an ancestor of origin/main (rejects tags pushed before the bump lands on main, or tags on old commits).
- Tag == package.json version guard moved before npm ci.
- Stale catalog snapshot now fails the run with instructions instead of committing on the tag tree, force-pushing main, and re-pointing the tag.
- ADR 0003 supersedes the 0002 self-heal behavior; release skill ritual updated (PR to main first, tag-only push).