### PR TITLE
chore: refresh model catalog snapshot (add Qwen3.8-27B)

### DIFF
--- a/src/catalog/snapshot.ts
+++ b/src/catalog/snapshot.ts
@@ -43,6 +43,7 @@ export const MODEL_SNAPSHOT: readonly CatalogModel[] = [
   { id: "xiaomi/mimo-v2.5-pro", name: "MiMo V2.5 Pro", contextLength: 1000000 },
   { id: "xiaomi/mimo-v2.5", name: "MiMo V2.5", contextLength: 1000000 },
   { id: "Qwen/Qwen3.8-Max", name: "Qwen 3.8 Max", contextLength: 1000000 },
+  { id: "Qwen/Qwen3.8-27B", name: "Qwen 3.8 27B", contextLength: 262144 },
   { id: "Qwen/Qwen3.7-Max", name: "Qwen 3.7 Max", contextLength: 1000000 },
   { id: "Qwen/Qwen3.7-Plus", name: "Qwen 3.7 Plus", contextLength: 1000000 },
   { id: "Qwen/Qwen3.7-Flash", name: "Qwen 3.7 Flash", contextLength: 1000000 },


### PR DESCRIPTION
Live catalog drifted — the snapshot was missing `Qwen/Qwen3.8-27B` (56 vs 55 models). Regenerated via `npm run refresh:snapshot`; per ADR 0003 a release would otherwise fail on the stale-snapshot gate.