### PR TITLE
chore(release): 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2 - 2026-08-19
+
+Chore: refresh the bundled model catalog snapshot after the live catalog drifted.
+
+- Added `Qwen/Qwen3.8-27B` (262144 context) to the bundled snapshot — the release pipeline's stale-snapshot gate would otherwise fail the next tag push (ADR 0003).
+
 ## 1.0.1 - 2026-08-16
 
 Chore: harden the release flow so a tag push can no longer publish from an unmerged tree or rewrite tags.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump + CHANGELOG entry for 1.0.2 (snapshot refresh: adds Qwen3.8-27B).