### PR TITLE
fix(models): sync reasoning efforts and modalities with command-code 1.28.1 catalog

### DIFF
--- a/src/provider/modalities.ts
+++ b/src/provider/modalities.ts
@@ -47,7 +47,6 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "thinkingmachines/inkling": ["text", "image"],
   "thinkingmachines/inkling-small": ["text", "image"],
   "xai/grok-4.5": ["text", "image"],
-  "xai/grok-4.6": ["text", "image"],
   "xiaomi/mimo-v2.5": ["text", "image"],
 }
 

--- a/src/provider/modalities.ts
+++ b/src/provider/modalities.ts
@@ -4,7 +4,7 @@
 export type CommandCodeInputType = "text" | "image"
 
 /**
- * Model input modalities from the command-code@1.15.1 bundled catalog.
+ * Model input modalities from the command-code@1.28.1 bundled catalog.
  * Models omitted here remain text-only so newly discovered IDs never claim
  * image support without upstream evidence.
  */
@@ -13,6 +13,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "Qwen/Qwen3.6-Plus": ["text", "image"],
   "Qwen/Qwen3.7-Flash": ["text", "image"],
   "Qwen/Qwen3.7-Plus": ["text", "image"],
+  "Qwen/Qwen3.8-27B": ["text", "image"],
   "Qwen/Qwen3.8-Max": ["text", "image"],
   "claude-fable-5": ["text", "image"],
   "claude-haiku-4-5-20251001": ["text", "image"],
@@ -25,6 +26,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "google/gemini-3.5-flash": ["text", "image"],
   "google/gemini-3.5-flash-lite": ["text", "image"],
   "google/gemini-3.6-flash": ["text", "image"],
+  "google/gemini-3.7-flash": ["text", "image"],
   "gpt-5.3-codex": ["text", "image"],
   "gpt-5.4": ["text", "image"],
   "gpt-5.4-mini": ["text", "image"],
@@ -45,6 +47,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "thinkingmachines/inkling": ["text", "image"],
   "thinkingmachines/inkling-small": ["text", "image"],
   "xai/grok-4.5": ["text", "image"],
+  "xai/grok-4.6": ["text", "image"],
   "xiaomi/mimo-v2.5": ["text", "image"],
 }
 

--- a/src/provider/reasoning.ts
+++ b/src/provider/reasoning.ts
@@ -8,12 +8,13 @@ type CommandCodeReasoningEffort = Exclude<PiThinkingLevel, "off">
  * Per-model reasoning efforts supported by Command Code's generate endpoint.
  *
  * The Provider API does not expose reasoning metadata. This is an exact
- * snapshot of `reasoningEfforts` from the command-code@1.15.1 model catalog
+ * snapshot of `reasoningEfforts` from the command-code@1.28.1 model catalog
  * (`packages/shared/src/model-catalog.ts`, also published in the generated
  * `dist/bundled/command-code-knowledge/reference/models.md`). Models omitted
  * here let Command Code choose their reasoning depth, matching the CLI.
  */
 export const MODEL_EFFORTS: Readonly<Record<string, readonly CommandCodeReasoningEffort[]>> = {
+  "Qwen/Qwen3.8-27B": ["low", "medium", "xhigh"],
   "Qwen/Qwen3.8-Max": ["low", "medium", "xhigh"],
   "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-7": ["low", "medium", "high", "xhigh", "max"],
@@ -34,9 +35,12 @@ export const MODEL_EFFORTS: Readonly<Record<string, readonly CommandCodeReasonin
   "google/gemini-3.5-flash": ["low", "medium", "high"],
   "google/gemini-3.5-flash-lite": ["low", "medium", "high"],
   "google/gemini-3.6-flash": ["low", "medium", "high"],
+  "google/gemini-3.7-flash": ["low", "medium", "high"],
   "sakana/fugu-ultra": ["high", "xhigh"],
   "xai/grok-4.5": ["low", "medium", "high"],
+  "xai/grok-4.6": ["low", "medium", "high", "xhigh"],
   "zai-org/GLM-5.2": ["high", "max"],
+  "zai-org/GLM-5.3": ["low", "high", "max"],
 }
 
 const PI_THINKING_LEVELS: readonly PiThinkingLevel[] = [

--- a/tests/modalities.test.ts
+++ b/tests/modalities.test.ts
@@ -21,8 +21,7 @@ run([
     () => {
       assertEqual(modelSupportsImageInput("Qwen/Qwen3.8-27B"), true)
       assertEqual(modelSupportsImageInput("google/gemini-3.7-flash"), true)
-      assertEqual(modelSupportsImageInput("xai/grok-4.6"), true)
-      assertEqual(inputModalitiesForModel("xai/grok-4.6"), ["text", "image"])
+      assertEqual(inputModalitiesForModel("xai/grok-4.6"), ["text"])
     },
   ],
 

--- a/tests/modalities.test.ts
+++ b/tests/modalities.test.ts
@@ -17,6 +17,16 @@ run([
   ],
 
   [
+    "vision models added in the command-code 1.28.1 catalog support image input",
+    () => {
+      assertEqual(modelSupportsImageInput("Qwen/Qwen3.8-27B"), true)
+      assertEqual(modelSupportsImageInput("google/gemini-3.7-flash"), true)
+      assertEqual(modelSupportsImageInput("xai/grok-4.6"), true)
+      assertEqual(inputModalitiesForModel("xai/grok-4.6"), ["text", "image"])
+    },
+  ],
+
+  [
     "unknown models default to text-only",
     () => {
       assertEqual(modelSupportsImageInput("brand-new/model"), false)

--- a/tests/reasoning.test.ts
+++ b/tests/reasoning.test.ts
@@ -23,6 +23,18 @@ run([
   ],
 
   [
+    "models added in the command-code 1.28.1 catalog expose efforts",
+    () => {
+      assertEqual(MODEL_EFFORTS["zai-org/GLM-5.3"], ["low", "high", "max"])
+      assertEqual(MODEL_EFFORTS["Qwen/Qwen3.8-27B"], ["low", "medium", "xhigh"])
+      assertEqual(MODEL_EFFORTS["google/gemini-3.7-flash"], ["low", "medium", "high"])
+      assertEqual(MODEL_EFFORTS["xai/grok-4.6"], ["low", "medium", "high", "xhigh"])
+      assertEqual(isReasoningModel("zai-org/GLM-5.3"), true)
+      assertEqual(isReasoningModel("xai/grok-4.6"), true)
+    },
+  ],
+
+  [
     "unknown models have no metadata",
     () => {
       assertEqual(thinkingMetadataForModel("brand-new/model"), undefined)
@@ -107,6 +119,16 @@ run([
       assert(variants, "expected variants")
       assertEqual(Object.keys(variants), ["high", "max"])
       assertEqual(variants.high, { reasoningEffort: "high" })
+      assertEqual(variants.max, { reasoningEffort: "max" })
+    },
+  ],
+
+  [
+    "reasoningVariantsForModel covers models added in the 1.28.1 catalog",
+    () => {
+      const variants = reasoningVariantsForModel("zai-org/GLM-5.3")
+      assert(variants, "expected variants")
+      assertEqual(Object.keys(variants), ["low", "high", "max"])
       assertEqual(variants.max, { reasoningEffort: "max" })
     },
   ],


### PR DESCRIPTION
## Problem

`MODEL_EFFORTS` and `MODEL_INPUT_MODALITIES` were snapshotted from `command-code@1.15.1` and have drifted from the live catalog. Concretely, against the `command-code@1.28.1` bundled catalog (`dist/bundled/command-code-knowledge/reference/models.md` and the model-catalog definitions in `dist/cli.mjs`):

**Missing reasoning efforts** (no `ctrl+t` variants in OpenCode):

| Model | 1.28.1 efforts |
|---|---|
| `zai-org/GLM-5.3` | low, high, max |
| `Qwen/Qwen3.8-27B` | low, medium, xhigh |
| `google/gemini-3.7-flash` | low, medium, high |
| `xai/grok-4.6` | low, medium, high, xhigh |

**Missing image input** (no vision in OpenCode):

- `Qwen/Qwen3.8-27B`
- `google/gemini-3.7-flash`

Note: `xai/grok-4.6` is **text-only** per the 1.28.1 catalog (`GROK_4_6 inputModalities:["text"]`) — it gets reasoning variants but not vision. It was initially mis-added to the vision table and corrected in a372f20.

This addresses the reasoning/vision part of #22 (the tool-call part is already correct on 1.0.2 — every model registers `toolcall: true`; the report was against 1.0.1's stale snapshot).

Fixes #22

## Solution

Additions only, no existing entry changed. Updated the table doc-comments to reference `command-code@1.28.1` and added unit tests covering the new models in both tables.

## Verification

- [x] `npm run build`
- [x] `npm run test:unit`
- [x] `npm run format:check`
- [x] `git diff --check`

Note: `npm run test:integration` has one pre-existing failure on `main` without these changes (`doStream surfaces a helpful no-key error` — expects "error", got "finish"), reproduced on a clean checkout, so it is not introduced by this PR.

## Follow-up

I'm preparing a second PR that extends `scripts/refresh-snapshot.mjs` so the release-time refresh also regenerates these tables from the `command-code` npm package, preventing this class of drift entirely.

Follow-up PR with the automation: #26