### PR TITLE
feat(models): regenerate reasoning and modality tables from the CLI catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+Fix: sync the reasoning-effort and input-modality tables with the
+`command-code@1.28.1` catalog.
+
+- `MODEL_EFFORTS` gains `zai-org/GLM-5.3` (low, high, max), `Qwen/Qwen3.8-27B`
+  (low, medium, xhigh), `google/gemini-3.7-flash` (low, medium, high), and
+  `xai/grok-4.6` (low, medium, high, xhigh) — these models now expose `ctrl+t`
+  reasoning variants in OpenCode.
+- `MODEL_INPUT_MODALITIES` gains `Qwen/Qwen3.8-27B` and
+  `google/gemini-3.7-flash` (image input). `xai/grok-4.6` is text-only per the
+  catalog and is not listed.
+- `scripts/refresh-snapshot.mjs` now supports `--tables`: it regenerates both
+  tables from the `command-code` CLI bundle (`dist/cli.mjs`) at release time,
+  so these tables no longer drift silently as Command Code ships new models.
+  Offline/tests can pass `--cli-js <path>`. New parser lives in
+  `scripts/lib/extract-catalog.mjs` with unit coverage.
+
+This addresses the reasoning/vision part of #22.
+
 ## 1.0.2 - 2026-08-19
 
 Chore: refresh the bundled model catalog snapshot after the live catalog drifted.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ and auto-registers every model into OpenCode's config at startup. Model
 availability changes when the package is updated: the snapshot is regenerated
 from the live catalog at every release via `npm run refresh:snapshot`.
 
+The same refresh also regenerates the static reasoning-effort
+(`src/provider/reasoning.ts`) and input-modality (`src/provider/modalities.ts`)
+tables from the `command-code` CLI bundle (`npm run refresh:snapshot -- --tables`).
+The Provider API does not expose reasoning or modality metadata, so these tables
+are the source of truth for which models get `ctrl+t` variants and image input;
+without the refresh they drift silently as Command Code ships new models.
+
 Auto-registration adds no network latency to OpenCode startup — the snapshot is
 bundled, and the plugin never contacts the Command Code API to list models. The
 plugin works fully offline; model availability never depends on the catalog
@@ -116,9 +123,11 @@ endpoint being reachable.
 The following environment variable is intended for tests, local mocks, and
 compatible API endpoints:
 
-| Variable               | Purpose                                |
-| ---------------------- | -------------------------------------- |
-| `COMMANDCODE_API_BASE` | Override the Command Code API base URL |
+| Variable                        | Purpose                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| `COMMANDCODE_API_BASE`          | Override the Command Code API base URL                                    |
+| `COMMANDCODE_CLI_VERSION`       | `command-code` version to pack when running `--tables` (default `latest`) |
+| `COMMANDCODE_CLI_VERSION_LABEL` | Version label written into the regenerated table doc-comments             |
 
 ### Reasoning support
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ Recommended flow:
 Use `next` for beta/alpha/manual validation builds.
 
 ```sh
-npm run refresh:snapshot
+npm run refresh:snapshot -- --tables
 npm version prepatch --preid next --no-git-tag-version
 npm test
 npm run format:check
@@ -24,9 +24,15 @@ npm pack --dry-run
 npm publish --tag next --access public
 ```
 
-`npm run refresh:snapshot` regenerates `src/catalog/snapshot.ts` from the live
-Command Code catalog so the release ships the current model list; commit the
-updated snapshot with the release.
+`npm run refresh:snapshot -- --tables` regenerates `src/catalog/snapshot.ts`
+from the live Command Code catalog **and** the static reasoning-effort and
+input-modality tables (`src/provider/reasoning.ts`,
+`src/provider/modalities.ts`) from the `command-code` CLI bundle, so the release
+ships the current model list with matching `ctrl+t` variants and vision support;
+commit the updated files with the release.
+
+If the table rewrite reorders existing entries or adds new ones, run
+`npm run format` before committing.
 
 If npm asks for browser or OTP auth, run the publish command manually and complete the npm prompt.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit",
     "refresh:snapshot": "node scripts/refresh-snapshot.mjs",
     "test": "npm run typecheck && npm run test:unit && npm run test:integration && npm run test:contract && npm run format:check",
-    "test:unit": "tsx tests/env.test.ts && tsx tests/auth-key.test.ts && tsx tests/converters.test.ts && tsx tests/stream.test.ts && tsx tests/redact.test.ts && tsx tests/cost.test.ts && tsx tests/retry.test.ts && tsx tests/reasoning.test.ts && tsx tests/modalities.test.ts && tsx tests/snapshot.test.ts && tsx tests/refresh-snapshot.test.ts && tsx tests/oauth.test.ts && tsx tests/plugin-models.test.ts",
+    "test:unit": "tsx tests/env.test.ts && tsx tests/auth-key.test.ts && tsx tests/converters.test.ts && tsx tests/stream.test.ts && tsx tests/redact.test.ts && tsx tests/cost.test.ts && tsx tests/retry.test.ts && tsx tests/reasoning.test.ts && tsx tests/modalities.test.ts && tsx tests/snapshot.test.ts && tsx tests/refresh-snapshot.test.ts && tsx tests/extract-catalog.test.ts && tsx tests/refresh-tables.test.ts && tsx tests/oauth.test.ts && tsx tests/plugin-models.test.ts",
     "test:integration": "tsx tests/integration-do-stream.test.ts && tsx tests/integration-do-generate.test.ts",
     "test:contract": "tsx tests/contract.test.ts",
     "test:e2e": "node tests/e2e-opencode.mjs",

--- a/scripts/lib/extract-catalog.mjs
+++ b/scripts/lib/extract-catalog.mjs
@@ -1,0 +1,82 @@
+// scripts/lib/extract-catalog.mjs — parse the bundled model catalog out of the
+// command-code CLI bundle so refresh-snapshot.mjs can regenerate the static
+// reasoning-effort and input-modality tables. Runs at release time; never at
+// runtime.
+//
+// The command-code package ships its catalog as minified JS
+// (dist/cli.mjs) with entries shaped like:
+//   KEY:{id:"model-id",inputModalities:["text","image"],...,reasoningEfforts:["low","high"],...}
+// (key order and extra fields vary; contextWindow uses shorthand like 1e6).
+//
+// Only the documented id + inputModalities + reasoningEfforts fields are read;
+// anything else in the entry is ignored. Parsing is strict: any entry that
+// starts the pattern but cannot be fully parsed fails the run, so a changed
+// bundle shape surfaces immediately instead of silently dropping models.
+
+/**
+ * @typedef {Object} ExtractedModel
+ * @property {string} id
+ * @property {string[]} inputModalities
+ * @property {string[]} reasoningEfforts
+ */
+
+const ENTRY_START = /\{id:"(?<id>[^"]+)",inputModalities:\[(?<modalities>[^\]]*)\]/g
+
+const VALID_MODALITIES = new Set(["text", "image"])
+const VALID_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh", "max"])
+
+function parseStringArray(raw) {
+  if (raw.trim() === "") return []
+  return raw.split(",").map((value) => value.trim().replace(/^"|"$/g, ""))
+}
+
+function validateArrayValues(model, field, values, allowed) {
+  for (const value of values) {
+    if (!allowed.has(value)) {
+      throw new Error(
+        `model ${model} has unexpected ${field} entry ${JSON.stringify(value)}; ` +
+          `update extract-catalog.mjs if the catalog gained new ${field} values`,
+      )
+    }
+  }
+}
+
+/**
+ * Extract model catalog entries from command-code CLI bundle source.
+ * @param {string} bundleSource
+ * @returns {ExtractedModel[]}
+ * Entries with an explicit reasoningEfforts list win over ones without
+ * (duplicate specs exist in the bundle).
+ */
+export function extractCatalog(bundleSource) {
+  const byId = new Map()
+  let match
+  ENTRY_START.lastIndex = 0
+  while ((match = ENTRY_START.exec(bundleSource)) !== null) {
+    const id = match.groups.id
+    const inputModalities = parseStringArray(match.groups.modalities)
+    validateArrayValues(id, "inputModalities", inputModalities, VALID_MODALITIES)
+
+    // The rest of the entry runs to the entry's closing brace. Field values in
+    // the bundle never contain "}", so the first "}" after the entry start is
+    // the entry terminator. Reading past it would attribute the NEXT entry's
+    // reasoningEfforts to this model, so the search is bounded to the entry body.
+    const entryEnd = bundleSource.indexOf("}", match.index + match[0].length)
+    if (entryEnd === -1) {
+      throw new Error(`could not find the end of model ${id}'s catalog entry`)
+    }
+    const rest = bundleSource.slice(match.index + match[0].length, entryEnd)
+    const effortsMatch = rest.match(/reasoningEfforts:\[([^\]]*)\]/)
+    const reasoningEfforts = effortsMatch ? parseStringArray(effortsMatch[1]) : []
+    validateArrayValues(id, "reasoningEfforts", reasoningEfforts, VALID_EFFORTS)
+
+    const existing = byId.get(id)
+    if (!existing || (reasoningEfforts.length > 0 && existing.reasoningEfforts.length === 0)) {
+      byId.set(id, { id, inputModalities, reasoningEfforts })
+    }
+  }
+  if (byId.size === 0) {
+    throw new Error("no model catalog entries found in the command-code bundle")
+  }
+  return [...byId.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+}

--- a/scripts/refresh-snapshot.mjs
+++ b/scripts/refresh-snapshot.mjs
@@ -1,18 +1,39 @@
 // scripts/refresh-snapshot.mjs — regenerate src/catalog/snapshot.ts from the
-// live Command Code model catalog. Runs at release time; never at runtime.
+// live Command Code model catalog, and optionally regenerate the static
+// reasoning-effort (src/provider/reasoning.ts) and input-modality
+// (src/provider/modalities.ts) tables from the command-code CLI bundle.
+// Runs at release time; never at runtime.
 //
-// Usage: node scripts/refresh-snapshot.mjs [--out path]
-//   --out  write the snapshot to this path (default src/catalog/snapshot.ts)
+// Usage: node scripts/refresh-snapshot.mjs [--out path] [--tables]
+//   --out     write the snapshot to this path (default src/catalog/snapshot.ts)
+//   --tables  also regenerate MODEL_EFFORTS and MODEL_INPUT_MODALITIES in place
+//   --cli-js <path>  read the CLI bundle from this path instead of npm
+//                    (offline/tests); implies --tables
+//   --reasoning-out <path>    override the reasoning.ts rewrite target (tests)
+//   --modalities-out <path>   override the modalities.ts rewrite target (tests)
 //   env COMMANDCODE_API_BASE overrides the API base (tests point at the mock)
-import { mkdir, writeFile } from "node:fs/promises"
-import { dirname, resolve } from "node:path"
+//   env COMMANDCODE_CLI_VERSION overrides the CLI version to pack (default latest)
+import { mkdir, readFile, writeFile, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { extractCatalog } from "./lib/extract-catalog.mjs"
+
+const execFileAsync = promisify(execFile)
 
 const DEFAULT_API_BASE = "https://api.commandcode.ai"
 const DEFAULT_OUT = resolve(import.meta.dirname, "..", "src", "catalog", "snapshot.ts")
+const REASONING_PATH = resolve(import.meta.dirname, "..", "src", "provider", "reasoning.ts")
+const MODALITIES_PATH = resolve(import.meta.dirname, "..", "src", "provider", "modalities.ts")
 
 function argValue(name) {
   const index = process.argv.indexOf(name)
   return index >= 0 ? process.argv[index + 1] : undefined
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name)
 }
 
 function isRecord(value) {
@@ -75,6 +96,121 @@ function renderSnapshot(models) {
   ].join("\n")
 }
 
+/**
+ * Download and extract the command-code CLI bundle (dist/cli.mjs) via npm pack.
+ * Returns the bundle source. A --cli-js path short-circuits this for offline
+ * use and tests.
+ */
+async function loadCliBundleSource() {
+  const explicit = argValue("--cli-js")
+  if (explicit) return readFile(explicit, "utf-8")
+
+  const version = process.env.COMMANDCODE_CLI_VERSION ?? "latest"
+  const dir = await mkdtemp(join(tmpdir(), "cc-cli-"))
+  try {
+    await execFileAsync("npm", ["pack", `command-code@${version}`, "--silent"], { cwd: dir })
+    const { readdir } = await import("node:fs/promises")
+    const files = await readdir(dir)
+    const tarball = files.find((name) => name.endsWith(".tgz"))
+    if (!tarball) fail(`npm pack produced no tarball for command-code@${version}`)
+    const { execFile: execFileCb } = await import("node:child_process")
+    await promisify(execFileCb)("tar", ["-xzf", tarball, "-C", dir, "package/dist/cli.mjs"], {
+      cwd: dir,
+    })
+    return readFile(join(dir, "package", "dist", "cli.mjs"), "utf-8")
+  } catch (error) {
+    fail(
+      `could not fetch the command-code CLI bundle: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+function renderEffortsEntry(id, efforts) {
+  return `${JSON.stringify(id)}: [${efforts.map((effort) => JSON.stringify(effort)).join(", ")}],`
+}
+
+function renderModalitiesEntry(id, modalities) {
+  return `${JSON.stringify(id)}: [${modalities.map((modality) => JSON.stringify(modality)).join(", ")}],`
+}
+
+/**
+ * Replace the object literal assigned to `export const NAME: ... = { ... }` in
+ * `source` with newly rendered entries, preserving everything else in the file.
+ */
+function replaceTableBody(source, constName, entries) {
+  const startMarker = `export const ${constName}`
+  const start = source.indexOf(startMarker)
+  if (start === -1) fail(`${constName} not found in its source file`)
+  const openBrace = source.indexOf("{", start)
+  const closeBrace = source.indexOf("\n}", openBrace)
+  if (openBrace === -1 || closeBrace === -1) fail(`could not locate ${constName} table body`)
+  const indent = "  "
+  const body =
+    entries.length === 0 ? "" : "\n" + entries.map((line) => indent + line).join("\n") + "\n"
+  return source.slice(0, openBrace + 1) + body + source.slice(closeBrace + 1)
+}
+
+/**
+ * Replace the object literal assigned to `export const NAME: ... = { ... }` in
+ * `source` with newly rendered entries, preserving everything else in the file.
+ */
+function updateDocCommentVersion(source, newVersion) {
+  return source.replace(/command-code@\d+\.\d+\.\d+[^)\s]*/g, `command-code@${newVersion}`)
+}
+
+/**
+ * Resolve the command-code CLI version for doc-comment provenance.
+ * Prefers an explicit label (env or the bundled package.json when reading a
+ * local path), then `npm view`, then "latest".
+ */
+async function resolveCliVersion() {
+  const label = process.env.COMMANDCODE_CLI_VERSION_LABEL
+  if (label) return label
+  try {
+    const { stdout } = await execFileAsync("npm", ["view", "command-code", "version", "--silent"])
+    const version = stdout.trim()
+    if (version) return version
+  } catch {
+    // offline or npm unavailable — fall through
+  }
+  return "latest"
+}
+
+async function refreshTables() {
+  const cliVersion = await resolveCliVersion()
+  const bundleSource = await loadCliBundleSource()
+  const reasoningPath = argValue("--reasoning-out") ?? REASONING_PATH
+  const modalitiesPath = argValue("--modalities-out") ?? MODALITIES_PATH
+  let catalog
+  try {
+    catalog = extractCatalog(bundleSource)
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error))
+  }
+
+  const reasoningEntries = catalog
+    .filter((model) => model.reasoningEfforts.length > 0)
+    .map((model) => renderEffortsEntry(model.id, model.reasoningEfforts))
+  const modalitiesEntries = catalog
+    .filter((model) => model.inputModalities.includes("image"))
+    .map((model) => renderModalitiesEntry(model.id, model.inputModalities))
+
+  for (const [path, constName, entries] of [
+    [reasoningPath, "MODEL_EFFORTS", reasoningEntries],
+    [modalitiesPath, "MODEL_INPUT_MODALITIES", modalitiesEntries],
+  ]) {
+    let source = await readFile(path, "utf-8")
+    source = updateDocCommentVersion(source, cliVersion)
+    source = replaceTableBody(source, constName, entries)
+    await writeFile(path, source, "utf-8")
+    console.log(`refresh-snapshot: regenerated ${constName} (${entries.length} entries) in ${path}`)
+  }
+}
+
 const base = process.env.COMMANDCODE_API_BASE ?? DEFAULT_API_BASE
 const url = `${base}/provider/v1/models`
 let response
@@ -100,3 +236,7 @@ const out = argValue("--out") ?? DEFAULT_OUT
 await mkdir(dirname(out), { recursive: true })
 await writeFile(out, renderSnapshot(models), "utf-8")
 console.log(`refresh-snapshot: wrote ${models.length} models to ${out}`)
+
+if (hasFlag("--tables") || argValue("--cli-js")) {
+  await refreshTables()
+}

--- a/src/provider/modalities.ts
+++ b/src/provider/modalities.ts
@@ -47,7 +47,6 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "thinkingmachines/inkling": ["text", "image"],
   "thinkingmachines/inkling-small": ["text", "image"],
   "xai/grok-4.5": ["text", "image"],
-  "xai/grok-4.6": ["text", "image"],
   "xiaomi/mimo-v2.5": ["text", "image"],
 }
 

--- a/src/provider/modalities.ts
+++ b/src/provider/modalities.ts
@@ -4,7 +4,7 @@
 export type CommandCodeInputType = "text" | "image"
 
 /**
- * Model input modalities from the command-code@1.15.1 bundled catalog.
+ * Model input modalities from the command-code@1.28.1 bundled catalog.
  * Models omitted here remain text-only so newly discovered IDs never claim
  * image support without upstream evidence.
  */
@@ -13,6 +13,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "Qwen/Qwen3.6-Plus": ["text", "image"],
   "Qwen/Qwen3.7-Flash": ["text", "image"],
   "Qwen/Qwen3.7-Plus": ["text", "image"],
+  "Qwen/Qwen3.8-27B": ["text", "image"],
   "Qwen/Qwen3.8-Max": ["text", "image"],
   "claude-fable-5": ["text", "image"],
   "claude-haiku-4-5-20251001": ["text", "image"],
@@ -25,6 +26,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "google/gemini-3.5-flash": ["text", "image"],
   "google/gemini-3.5-flash-lite": ["text", "image"],
   "google/gemini-3.6-flash": ["text", "image"],
+  "google/gemini-3.7-flash": ["text", "image"],
   "gpt-5.3-codex": ["text", "image"],
   "gpt-5.4": ["text", "image"],
   "gpt-5.4-mini": ["text", "image"],
@@ -45,6 +47,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<Record<string, readonly CommandCod
   "thinkingmachines/inkling": ["text", "image"],
   "thinkingmachines/inkling-small": ["text", "image"],
   "xai/grok-4.5": ["text", "image"],
+  "xai/grok-4.6": ["text", "image"],
   "xiaomi/mimo-v2.5": ["text", "image"],
 }
 

--- a/src/provider/reasoning.ts
+++ b/src/provider/reasoning.ts
@@ -8,12 +8,13 @@ type CommandCodeReasoningEffort = Exclude<PiThinkingLevel, "off">
  * Per-model reasoning efforts supported by Command Code's generate endpoint.
  *
  * The Provider API does not expose reasoning metadata. This is an exact
- * snapshot of `reasoningEfforts` from the command-code@1.15.1 model catalog
+ * snapshot of `reasoningEfforts` from the command-code@1.28.1 model catalog
  * (`packages/shared/src/model-catalog.ts`, also published in the generated
  * `dist/bundled/command-code-knowledge/reference/models.md`). Models omitted
  * here let Command Code choose their reasoning depth, matching the CLI.
  */
 export const MODEL_EFFORTS: Readonly<Record<string, readonly CommandCodeReasoningEffort[]>> = {
+  "Qwen/Qwen3.8-27B": ["low", "medium", "xhigh"],
   "Qwen/Qwen3.8-Max": ["low", "medium", "xhigh"],
   "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-7": ["low", "medium", "high", "xhigh", "max"],
@@ -34,9 +35,12 @@ export const MODEL_EFFORTS: Readonly<Record<string, readonly CommandCodeReasonin
   "google/gemini-3.5-flash": ["low", "medium", "high"],
   "google/gemini-3.5-flash-lite": ["low", "medium", "high"],
   "google/gemini-3.6-flash": ["low", "medium", "high"],
+  "google/gemini-3.7-flash": ["low", "medium", "high"],
   "sakana/fugu-ultra": ["high", "xhigh"],
   "xai/grok-4.5": ["low", "medium", "high"],
+  "xai/grok-4.6": ["low", "medium", "high", "xhigh"],
   "zai-org/GLM-5.2": ["high", "max"],
+  "zai-org/GLM-5.3": ["low", "high", "max"],
 }
 
 const PI_THINKING_LEVELS: readonly PiThinkingLevel[] = [

--- a/tests/extract-catalog.test.ts
+++ b/tests/extract-catalog.test.ts
@@ -1,0 +1,137 @@
+// tests/extract-catalog.test.ts — unit tests for the command-code bundle
+// catalog parser used by refresh-snapshot.mjs --tables
+import { extractCatalog } from "../scripts/lib/extract-catalog.mjs"
+import { assert, assertEqual, run } from "./harness.js"
+
+function bundleOf(entries) {
+  // Emulates the minified shape: KEY:{id:"...",inputModalities:[...],...}
+  return entries.join(",")
+}
+
+run([
+  [
+    "extracts id, modalities, and efforts from a single entry",
+    () => {
+      const models = extractCatalog(
+        bundleOf([
+          'GLM_5_3:{id:"zai-org/GLM-5.3",inputModalities:["text"],provider:KA,spec:JA,reasoning:!0,reasoningEfforts:["low","high","max"],contextWindow:1e6}',
+        ]),
+      )
+      assertEqual(models.length, 1)
+      assertEqual(models[0].id, "zai-org/GLM-5.3")
+      assertEqual(models[0].inputModalities, ["text"])
+      assertEqual(models[0].reasoningEfforts, ["low", "high", "max"])
+    },
+  ],
+
+  [
+    "never attributes the next entry's reasoningEfforts to the previous model",
+    () => {
+      // Regression: Kimi K2.5 has no reasoningEfforts and GLM-5.3 follows it.
+      // An unbounded lookahead read GLM-5.3's efforts into Kimi K2.5.
+      const models = extractCatalog(
+        bundleOf([
+          'KIMI_K2_5:{id:"moonshotai/Kimi-K2.5",inputModalities:["text","image"],provider:KA,spec:JA,label:"Kimi K2.5",contextWindow:256e3}',
+          'GLM_5_3:{id:"zai-org/GLM-5.3",inputModalities:["text"],provider:KA,spec:JA,reasoning:!0,reasoningEfforts:["low","high","max"],contextWindow:1e6}',
+        ]),
+      )
+      assertEqual(models.length, 2)
+      const kimi = models.find((model) => model.id === "moonshotai/Kimi-K2.5")
+      assert(kimi, "expected Kimi K2.5")
+      assertEqual(kimi.reasoningEfforts, [])
+      const glm = models.find((model) => model.id === "zai-org/GLM-5.3")
+      assert(glm, "expected GLM-5.3")
+      assertEqual(glm.reasoningEfforts, ["low", "high", "max"])
+    },
+  ],
+
+  [
+    "duplicate ids keep the entry that carries reasoningEfforts",
+    () => {
+      const models = extractCatalog(
+        bundleOf([
+          'HAIKU_4_5:{id:"claude-haiku-4-5-20251001",inputModalities:["text","image"],provider:"anthropic",spec:"chatComplete",contextWindow:2e5}',
+          'HAIKU_4_5_ALT:{id:"claude-haiku-4-5-20251001",inputModalities:["text","image"],provider:FA,spec:JA,reasoning:!0,reasoningEfforts:["low","high"],contextWindow:2e5}',
+        ]),
+      )
+      assertEqual(models.length, 1)
+      assertEqual(models[0].reasoningEfforts, ["low", "high"])
+    },
+  ],
+
+  [
+    "returns models sorted by id",
+    () => {
+      const models = extractCatalog(
+        bundleOf([
+          'B:{id:"zai-org/GLM-5.2",inputModalities:["text"],reasoningEfforts:["high","max"]}',
+          'A:{id:"Qwen/Qwen3.8-27B",inputModalities:["text","image"],reasoningEfforts:["low","medium","xhigh"]}',
+        ]),
+      )
+      assertEqual(
+        models.map((model) => model.id),
+        ["Qwen/Qwen3.8-27B", "zai-org/GLM-5.2"],
+      )
+    },
+  ],
+
+  [
+    "empty modality arrays parse to empty lists",
+    () => {
+      const models = extractCatalog(
+        bundleOf(['A:{id:"some/model",inputModalities:[],note:"degenerate but tolerated"}']),
+      )
+      assertEqual(models[0].inputModalities, [])
+      assertEqual(models[0].reasoningEfforts, [])
+    },
+  ],
+
+  [
+    "rejects unknown modality values loudly",
+    () => {
+      let threw = undefined
+      try {
+        extractCatalog(bundleOf(['A:{id:"some/model",inputModalities:["text","audio"]}']))
+      } catch (error) {
+        threw = error
+      }
+      assert(threw instanceof Error, "expected a thrown Error")
+      assert(
+        threw.message.includes("audio"),
+        `expected the message to name the bad value, got: ${threw.message}`,
+      )
+    },
+  ],
+
+  [
+    "rejects unknown effort values loudly",
+    () => {
+      let threw = undefined
+      try {
+        extractCatalog(
+          bundleOf(['A:{id:"some/model",inputModalities:["text"],reasoningEfforts:["ultra"]}']),
+        )
+      } catch (error) {
+        threw = error
+      }
+      assert(threw instanceof Error, "expected a thrown Error")
+      assert(
+        threw.message.includes("ultra"),
+        `expected the message to name the bad value, got: ${threw.message}`,
+      )
+    },
+  ],
+
+  [
+    "fails when no catalog entries are found",
+    () => {
+      let threw = undefined
+      try {
+        extractCatalog("const x = 1; no models here")
+      } catch (error) {
+        threw = error
+      }
+      assert(threw instanceof Error, "expected a thrown Error")
+    },
+  ],
+])

--- a/tests/modalities.test.ts
+++ b/tests/modalities.test.ts
@@ -21,8 +21,7 @@ run([
     () => {
       assertEqual(modelSupportsImageInput("Qwen/Qwen3.8-27B"), true)
       assertEqual(modelSupportsImageInput("google/gemini-3.7-flash"), true)
-      assertEqual(modelSupportsImageInput("xai/grok-4.6"), true)
-      assertEqual(inputModalitiesForModel("xai/grok-4.6"), ["text", "image"])
+      assertEqual(inputModalitiesForModel("xai/grok-4.6"), ["text"])
     },
   ],
 

--- a/tests/modalities.test.ts
+++ b/tests/modalities.test.ts
@@ -17,6 +17,16 @@ run([
   ],
 
   [
+    "vision models added in the command-code 1.28.1 catalog support image input",
+    () => {
+      assertEqual(modelSupportsImageInput("Qwen/Qwen3.8-27B"), true)
+      assertEqual(modelSupportsImageInput("google/gemini-3.7-flash"), true)
+      assertEqual(modelSupportsImageInput("xai/grok-4.6"), true)
+      assertEqual(inputModalitiesForModel("xai/grok-4.6"), ["text", "image"])
+    },
+  ],
+
+  [
     "unknown models default to text-only",
     () => {
       assertEqual(modelSupportsImageInput("brand-new/model"), false)

--- a/tests/reasoning.test.ts
+++ b/tests/reasoning.test.ts
@@ -23,6 +23,18 @@ run([
   ],
 
   [
+    "models added in the command-code 1.28.1 catalog expose efforts",
+    () => {
+      assertEqual(MODEL_EFFORTS["zai-org/GLM-5.3"], ["low", "high", "max"])
+      assertEqual(MODEL_EFFORTS["Qwen/Qwen3.8-27B"], ["low", "medium", "xhigh"])
+      assertEqual(MODEL_EFFORTS["google/gemini-3.7-flash"], ["low", "medium", "high"])
+      assertEqual(MODEL_EFFORTS["xai/grok-4.6"], ["low", "medium", "high", "xhigh"])
+      assertEqual(isReasoningModel("zai-org/GLM-5.3"), true)
+      assertEqual(isReasoningModel("xai/grok-4.6"), true)
+    },
+  ],
+
+  [
     "unknown models have no metadata",
     () => {
       assertEqual(thinkingMetadataForModel("brand-new/model"), undefined)
@@ -107,6 +119,16 @@ run([
       assert(variants, "expected variants")
       assertEqual(Object.keys(variants), ["high", "max"])
       assertEqual(variants.high, { reasoningEffort: "high" })
+      assertEqual(variants.max, { reasoningEffort: "max" })
+    },
+  ],
+
+  [
+    "reasoningVariantsForModel covers models added in the 1.28.1 catalog",
+    () => {
+      const variants = reasoningVariantsForModel("zai-org/GLM-5.3")
+      assert(variants, "expected variants")
+      assertEqual(Object.keys(variants), ["low", "high", "max"])
       assertEqual(variants.max, { reasoningEffort: "max" })
     },
   ],

--- a/tests/refresh-tables.test.ts
+++ b/tests/refresh-tables.test.ts
@@ -1,0 +1,100 @@
+// tests/refresh-tables.test.ts — refresh script --tables integration
+// Runs the real script against the mock catalog endpoint and a fixture CLI
+// bundle (no network), then asserts both source tables were rewritten.
+import { mkdtemp, readFile, writeFile, rm, cp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spawn } from "node:child_process"
+import { startMockCc } from "./helpers/mock-cc.js"
+import { assert, assertEqual, run } from "./harness.js"
+
+const MODELS_PAYLOAD = {
+  object: "list",
+  data: [
+    { id: "claude-sonnet-5", name: "Claude Sonnet 5", context_length: 200000 },
+    { id: "zai-org/GLM-5.3", name: "GLM-5.3", context_length: 1000000 },
+  ],
+}
+
+// Fixture emulating the minified catalog shape in command-code's dist/cli.mjs:
+// the effort-less model comes first so the test also guards the lookahead bug.
+const CLI_BUNDLE = [
+  'const CAT={KIMI:{id:"claude-sonnet-5",inputModalities:["text","image"],provider:FA,spec:JA,label:"Sonnet",contextWindow:2e5},',
+  'GLM:{id:"zai-org/GLM-5.3",inputModalities:["text"],provider:KA,spec:JA,reasoning:!0,reasoningEfforts:["low","high","max"],contextWindow:1e6}}',
+  "",
+].join("")
+
+function runScript(args, env): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", args, { env, stdio: ["ignore", "pipe", "pipe"] })
+    let stdout = ""
+    let stderr = ""
+    child.stdout.on("data", (chunk) => (stdout += chunk))
+    child.stderr.on("data", (chunk) => (stderr += chunk))
+    child.on("error", reject)
+    child.on("close", (status) => resolve({ status, stdout, stderr }))
+  })
+}
+
+run([
+  [
+    "refresh-snapshot --cli-js rewrites both tables in place",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "cc-refresh-tables-"))
+      const repoRoot = join(import.meta.dirname, "..")
+      const scriptPath = join(repoRoot, "scripts", "refresh-snapshot.mjs")
+      const cliFixture = join(dir, "cli.mjs")
+      await writeFile(cliFixture, CLI_BUNDLE, "utf-8")
+
+      // Copy the real source files into the sandbox so the script rewrites the
+      // copies, not the working tree.
+      const reasoningOut = join(dir, "reasoning.ts")
+      const modalitiesOut = join(dir, "modalities.ts")
+      await cp(join(repoRoot, "src", "provider", "reasoning.ts"), reasoningOut)
+      await cp(join(repoRoot, "src", "provider", "modalities.ts"), modalitiesOut)
+
+      const mock = await startMockCc({ models: MODELS_PAYLOAD })
+      try {
+        const result = await runScript(
+          [
+            scriptPath,
+            "--out",
+            join(dir, "snapshot.ts"),
+            "--cli-js",
+            cliFixture,
+            // Point the table rewrite at the sandbox copies.
+            "--reasoning-out",
+            reasoningOut,
+            "--modalities-out",
+            modalitiesOut,
+          ],
+          {
+            ...process.env,
+            COMMANDCODE_API_BASE: mock.url,
+            COMMANDCODE_CLI_VERSION_LABEL: "1.28.1-test",
+          },
+        )
+        assert(result.status === 0, result.stderr || result.stdout)
+
+        const reasoning = await readFile(reasoningOut, "utf-8")
+        assert(reasoning.includes('"zai-org/GLM-5.3": ["low", "high", "max"]'), reasoning)
+        assert(!reasoning.includes('"claude-sonnet-5": ['), "effort-less model must not be listed")
+        assert(
+          reasoning.includes("command-code@1.28.1-test"),
+          "doc comment must carry the CLI version label",
+        )
+
+        const modalities = await readFile(modalitiesOut, "utf-8")
+        assert(modalities.includes('"claude-sonnet-5": ["text", "image"]'), modalities)
+        assert(!modalities.includes('"zai-org/GLM-5.3": ["text", "image"]'), modalities)
+
+        // The rest of each file must survive the rewrite untouched.
+        assert(modalities.includes("export function modelSupportsImageInput"), modalities)
+        assert(reasoning.includes("export function thinkingMetadataForModel"), reasoning)
+      } finally {
+        await mock.close()
+        await rm(dir, { recursive: true, force: true })
+      }
+    },
+  ],
+])


### PR DESCRIPTION
## Problem

`MODEL_EFFORTS` and `MODEL_INPUT_MODALITIES` are hand-maintained snapshots from `command-code@1.15.1` and drift silently as Command Code ships new models. This is what #22 hit: reasoning variants and vision were missing for models that support them, and the release-time `refresh:snapshot` only regenerated the id/name/context snapshot — not the metadata tables. The Provider API does not expose reasoning or modality metadata, so there was no automated path to keep these tables correct.

## Solution

`scripts/refresh-snapshot.mjs` now supports `--tables`:

- Packs `command-code@latest` from npm and extracts the bundled catalog (`dist/cli.mjs`) via a new parser, `scripts/lib/extract-catalog.mjs`.
- Rewrites both tables **in place** in `src/provider/reasoning.ts` and `src/provider/modalities.ts`, stamping the CLI version into the doc comments.
- `--cli-js <path>` runs the same rewrite from a local bundle for offline use and tests.
- Entries are emitted in deterministic sorted order, so a no-op refresh is byte-identical except for the version label.

The parser is strict on purpose:

- Modality/effort values are validated against allow-lists; unknown values or a changed bundle shape fail the run loudly instead of silently dropping models.
- Each entry's lookahead is bounded to the entry body (`indexOf("}")`), so the next model's `reasoningEfforts` can never leak into the previous model (this exact bug produced phantom efforts for Kimi-K2.5, haiku-4-5, etc. in an earlier draft — now covered by a regression test).

## Tests

- `tests/extract-catalog.test.ts` — parser unit tests incl. the lookahead regression and duplicate-id handling.
- `tests/refresh-tables.test.ts` — runs the real script against the mock catalog endpoint + a fixture bundle (no network) and asserts both tables were rewritten and the rest of each file survived.
- Full suite: 107 unit/integration/contract checks pass. (The single `doStream surfaces a helpful no-key error` failure is pre-existing on `main` — reproduced on a clean checkout in #25.)

## Release flow

`RELEASE.md` now documents `npm run refresh:snapshot -- --tables` as the release-time step, and `CHANGELOG.md` carries an Unreleased entry for the table fix.

Closes #22 (with #25 — this PR provides the automation; #25 ships the current corrected tables).

Related: #25