### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.1 - 2026-08-20
 
 Fix: generate image-input modalities from the Command Code CLI catalog.
 
@@ -11,6 +11,8 @@ Fix: generate image-input modalities from the Command Code CLI catalog.
   data.
 - Added AST parser and offline coverage for reordered fields, duplicate model
   entries, malformed bundles, and text-only fallback behavior.
+- Docs: the release skill and facts-sync spec now describe the modality
+  refresh and the new release-gate failure mode.
 
 ## 1.1.0 - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Fix: generate image-input modalities from the Command Code CLI catalog.
   entries, malformed bundles, and text-only fallback behavior.
 - Docs: the release skill and facts-sync spec now describe the modality
   refresh and the new release-gate failure mode.
+- Thanks to @ericpastorm for #31, which auto-syncs the input-modality table
+  from the CLI catalog.
 
 ## 1.1.0 - 2026-08-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release 1.1.1 — modalities auto-sync (#31) plus the release-skill/spec docs (#33).

Bumps package.json to 1.1.1 and promotes the Unreleased CHANGELOG section into the release body. Merge, then tag `v1.1.1`.