### PR TITLE
fix(stream): emit cache-inclusive input token totals

### DIFF
--- a/src/provider/command-code-model.ts
+++ b/src/provider/command-code-model.ts
@@ -28,7 +28,7 @@ import {
 } from "./converters.js"
 import { parseStreamEventLine, ccEventToStreamPart } from "./stream.js"
 import { redactCommandCodeErrorText, commandCodeErrorMessage } from "./redact.js"
-import { calculateCommandCodeCost } from "./cost.js"
+import { calculateCommandCodeCost, costUsageFromAiSdkUsage } from "./cost.js"
 import { ZERO_MODEL_COST, MODEL_COSTS } from "./pricing.js"
 import {
   mappedReasoningEffort,
@@ -323,14 +323,7 @@ export class CommandCodeLanguageModel implements LanguageModelV3 {
             for (const part of parts) {
               if (part.type === "finish") {
                 finished = true
-                const usage = part.usage
-                calculateCommandCodeCost(this.costForModel(), {
-                  input: usage.inputTokens.total ?? 0,
-                  output: usage.outputTokens.total ?? 0,
-                  cacheRead: 0,
-                  cacheWrite: 0,
-                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-                })
+                calculateCommandCodeCost(this.costForModel(), costUsageFromAiSdkUsage(part.usage))
               }
               emit(part)
             }

--- a/src/provider/cost.ts
+++ b/src/provider/cost.ts
@@ -1,5 +1,6 @@
 // src/provider/cost.ts — local cost calculation for Command Code usage
 // (PLAN #6, port of pi's cost.ts; longWrite arithmetic verbatim)
+import type { LanguageModelV3Usage } from "@ai-sdk/provider"
 import type { CommandCodeModelCost } from "./pricing.js"
 
 export interface CostUsage {
@@ -13,6 +14,21 @@ export interface CostUsage {
 
 export interface CostModel {
   cost: CommandCodeModelCost
+}
+
+/**
+ * Maps an emitted AI SDK v3 usage onto billable token counts: fresh input
+ * (`noCache`), cache read, and cache write each bill at their own rate, so
+ * the cache-inclusive `total` must not be billed as fresh input (issue #36).
+ */
+export function costUsageFromAiSdkUsage(usage: LanguageModelV3Usage): CostUsage {
+  return {
+    input: usage.inputTokens.noCache ?? 0,
+    output: usage.outputTokens.total ?? 0,
+    cacheRead: usage.inputTokens.cacheRead ?? 0,
+    cacheWrite: usage.inputTokens.cacheWrite ?? 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }
 }
 
 export function calculateCommandCodeCost(model: CostModel, usage: CostUsage): void {

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -7,9 +7,10 @@
 //     (with id + argsTextDelta as delta), then a final tool-call part
 //   - finishReason is { unified, raw }
 //   - usage is nested { inputTokens: { total, noCache, cacheRead, cacheWrite },
-//     outputTokens: { total } } — cache tokens are folded into the input
-//     totals the way pi folds them into its usage shape (AI SDK v3 has no
-//     separate cache fields on the model-facing shape we emit here).
+//     outputTokens: { total } } — `total` is cache-inclusive per AI SDK v3
+//     convention (how the bundled Anthropic provider maps usage); `noCache`
+//     carries the fresh-only remainder so downstream context usage and local
+//     cost stay correct (issue #36).
 import type {
   LanguageModelV3StreamPart,
   LanguageModelV3Usage,
@@ -54,13 +55,13 @@ export function ccUsageToAiSdkUsage(
   if (!isRecord(usage)) return undefined
   const details = isRecord(usage.inputTokenDetails) ? usage.inputTokenDetails : undefined
   const totalInput = numberValue(usage.inputTokens) ?? 0
-  const noCache = numberValue(details?.noCacheTokens)
   const cacheRead = numberValue(details?.cacheReadTokens) ?? 0
   const cacheWrite = numberValue(details?.cacheWriteTokens) ?? 0
-  const inputTotal = noCache ?? Math.max(0, totalInput - cacheRead - cacheWrite)
+  const explicitNoCache = numberValue(details?.noCacheTokens)
+  const noCache = explicitNoCache ?? Math.max(0, totalInput - cacheRead - cacheWrite)
   const outputTokens = numberValue(usage.outputTokens) ?? 0
   return {
-    inputTokens: { total: inputTotal, noCache: inputTotal, cacheRead, cacheWrite },
+    inputTokens: { total: totalInput, noCache, cacheRead, cacheWrite },
     outputTokens: { total: outputTokens, text: outputTokens, reasoning: 0 },
   }
 }

--- a/tests/cost.test.ts
+++ b/tests/cost.test.ts
@@ -1,6 +1,6 @@
 // tests/cost.test.ts — pricing table + cost calculation (PLAN #6, port of pi's
 // test-cost.ts; locks arithmetic to pi-ai's calculateCost)
-import { calculateCommandCodeCost } from "../src/provider/cost.js"
+import { calculateCommandCodeCost, costUsageFromAiSdkUsage } from "../src/provider/cost.js"
 import { MODEL_COSTS } from "../src/provider/pricing.js"
 import { assertEqual, run } from "./harness.js"
 
@@ -43,6 +43,26 @@ run([
       const u = usage(100_000, 0, 100_000, 0)
       calculateCommandCodeCost({ cost: rates }, u)
       assertEqual(u.cost.cacheRead, 0.01)
+    },
+  ],
+
+  [
+    "stream usage bills fresh input, cache read and cache write separately (issue #36)",
+    () => {
+      const u = costUsageFromAiSdkUsage({
+        inputTokens: { total: 100_000, noCache: 40_000, cacheRead: 30_000, cacheWrite: 30_000 },
+        outputTokens: { total: 50_000, text: 50_000, reasoning: 0 },
+      })
+      assertEqual(u.input, 40_000)
+      assertEqual(u.output, 50_000)
+      assertEqual(u.cacheRead, 30_000)
+      assertEqual(u.cacheWrite, 30_000)
+      calculateCommandCodeCost({ cost: { input: 1, output: 5, cacheRead: 0.5, cacheWrite: 3 } }, u)
+      assertEqual(u.cost.input, 0.04)
+      assertEqual(u.cost.output, 0.25)
+      assertEqual(u.cost.cacheRead, 0.015)
+      assertEqual(u.cost.cacheWrite, 0.09)
+      assertEqual(u.cost.total, 0.395)
     },
   ],
 

--- a/tests/integration-do-stream.test.ts
+++ b/tests/integration-do-stream.test.ts
@@ -55,6 +55,37 @@ run([
   ],
 
   [
+    "finish usage includes cached input tokens (issue #36)",
+    async () => {
+      const mock = await startMockCc({
+        stream: [
+          textDelta("hi"),
+          finishEvent({
+            totalUsage: {
+              inputTokens: 100,
+              outputTokens: 50,
+              inputTokenDetails: { noCacheTokens: 40, cacheReadTokens: 30, cacheWriteTokens: 30 },
+            },
+          }),
+        ],
+      })
+      try {
+        const provider = createCommandCode({ apiKey: "user_test", baseURL: mock.url })
+        const parts = await collect(provider.languageModel("claude-sonnet-5"), [
+          { role: "user", content: "hi" },
+        ])
+        const finish = parts.find((p) => p.type === "finish") as { usage?: unknown }
+        assertEqual(finish.usage, {
+          inputTokens: { total: 100, noCache: 40, cacheRead: 30, cacheWrite: 30 },
+          outputTokens: { total: 50, text: 50, reasoning: 0 },
+        })
+      } finally {
+        await mock.close()
+      }
+    },
+  ],
+
+  [
     "streams reasoning deltas before text",
     async () => {
       const mock = await startMockCc({

--- a/tests/stream.test.ts
+++ b/tests/stream.test.ts
@@ -215,7 +215,7 @@ run([
       assertEqual(finish.type, "finish")
       assertEqual(finish.finishReason, { unified: "stop", raw: "stop" })
       assertEqual(finish.usage, {
-        inputTokens: { total: 7, noCache: 7, cacheRead: 2, cacheWrite: 1 },
+        inputTokens: { total: 10, noCache: 7, cacheRead: 2, cacheWrite: 1 },
         outputTokens: { total: 5, text: 5, reasoning: 0 },
       })
     },
@@ -252,9 +252,11 @@ run([
   ],
 
   [
-    "ccUsageToAiSdkUsage handles cache details",
+    "ccUsageToAiSdkUsage emits cache-inclusive input totals (issue #36)",
     () => {
       // Plan contract: the function reads `totalUsage` from the finish event.
+      // AI SDK convention: `total` includes cached tokens; `noCache` is the
+      // fresh-only remainder — otherwise downstream context usage renders low.
       const usage = ccUsageToAiSdkUsage({
         totalUsage: {
           inputTokens: 100,
@@ -263,7 +265,24 @@ run([
         },
       })
       assertEqual(usage, {
-        inputTokens: { total: 40, noCache: 40, cacheRead: 30, cacheWrite: 30 },
+        inputTokens: { total: 100, noCache: 40, cacheRead: 30, cacheWrite: 30 },
+        outputTokens: { total: 50, text: 50, reasoning: 0 },
+      })
+    },
+  ],
+
+  [
+    "ccUsageToAiSdkUsage derives noCache when details omit it",
+    () => {
+      const usage = ccUsageToAiSdkUsage({
+        totalUsage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          inputTokenDetails: { cacheReadTokens: 30, cacheWriteTokens: 20 },
+        },
+      })
+      assertEqual(usage, {
+        inputTokens: { total: 100, noCache: 50, cacheRead: 30, cacheWrite: 20 },
         outputTokens: { total: 50, text: 50, reasoning: 0 },
       })
     },


### PR DESCRIPTION
Closes #36

## Problem

When using a `[CMD]` model through OpenChamber, context usage rendered far too low (~0.1% instead of ~5%). The OpenCode CLI looked correct because its UI sums all token fields, masking the split.

## Root cause

`ccUsageToAiSdkUsage()` emitted `inputTokens.total` as the *non-cached* input only, parking cache read/write in the nested detail fields. The AI SDK convention is the opposite: `total` includes cached tokens; `noCache` carries the fresh-only remainder (as the bundled Anthropic provider maps it). Downstream, the AI SDK derives `totalTokens = inputTokens.total + outputTokens.total`, OpenCode persists that as `tokens.total`, and OpenChamber renders it as context usage.

## Changes

- `ccUsageToAiSdkUsage()` now emits cache-inclusive `inputTokens.total` with fresh-only `noCache` (explicit `noCacheTokens` when present, else derived as input − cacheRead − cacheWrite); no-details fallback preserved
- New `costUsageFromAiSdkUsage()` maps v3 usage onto billable counts so fresh input, cache reads, and cache writes bill at their own rates
- Stream handler passes parsed cache token counts to the cost calculator instead of hardcoding zeros

## Testing

- Updated stream-converter assertions that pinned the old exclusive totals
- Added unit tests: cache-inclusive emission, derived-`noCache` fallback, per-rate billing split
- Added end-to-end integration test through the mock CC server
- Full `npm test` green: typecheck, 168 unit, integration, contract, format

## Out of scope (per issue)

OpenChamber's display and OpenCode's `tokens.total` persistence.