### PR TITLE
docs: simplify Install, correct install command, add agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,61 @@
+# opencode-cmd-provider
+
+opencode plugin + provider: `provider.commandcode` auto-registration, `[CMD]`
+models, `COMMANDCODE_API_KEY` auth, `provider/*` streaming, plus a Deals
+intelligence slice. Domain vocabulary lives in `CONTEXT.md`; architectural
+decisions in `docs/adr/`.
+
+## Commands
+
+- `npm run build` runs `tsc` then `bun scripts/build-tui.ts`. **`bun` must be on
+  PATH** — the TUI (`dist/tui.js`) is built with bun because `tsc`'s `react-jsx`
+  emit is non-reactive (props freeze; the sidebar never repaints). CI installs
+  bun.
+- `npm test` = typecheck → unit → integration → contract → `format:check`.
+- Single test: `npx tsx tests/<file>.test.ts`. Tests are plain `.test.ts` files
+  run by `tsx` (no vitest/jest); helpers `run`/`assert`/`assertEqual` come from
+  `tests/harness.ts`.
+- **New test files must be added to the `test:unit` script in `package.json`**
+  (it is an explicit `&&` list, not a glob) or CI won't run them.
+- `npm run test:e2e` needs a real `opencode` binary on PATH and is excluded from
+  `npm test`. Its headless `opencode run` leg deliberately skips — upstream
+  opencode bug (anomalyco/opencode #14956, #5674). Don't "fix" the skip.
+
+## Generated files — do not hand-edit
+
+`src/catalog/snapshot.ts`, `src/catalog/facts.ts`, and `src/deals/catalog.ts`
+are generated (`scripts/refresh-snapshot.mjs`, `scripts/refresh-deals.mjs`).
+Regenerate with `npm run refresh` (offline from `tests/fixtures/*.html`).
+`refresh:deals` never exits non-zero — on a mitigated scrape it falls back to
+fixtures/empty catalog with a warning, so it can't block release.
+
+## Architecture
+
+- **Two hosts, two config files.** The server host reads `opencode.json`
+  (`src/plugin/index.ts`, package export `"."`); the TUI host reads `tui.json`
+  (`src/deals/tui.tsx`, package export `"./tui"` → `dist/tui.js`). The TUI host
+  never reads `opencode.json` (verified, ADR-0004).
+- **`src/deals/` is the excisable Deals slice.** Deleting it plus the two
+  registration lines in `src/plugin/index.ts` leaves Core green. Keep the server
+  barrel `src/deals/index.ts` free of the TUI re-exports — exporting `tui.tsx`
+  from it pulls `solid-js`/`@opentui` into the server bundle.
+- The install command is `opencode plugin <pkg>` — **there is no `add`
+  subcommand** on opencode 1.18+.
+
+## Conventions
+
+- Angular Conventional Commits; types/scopes in `CONTRIBUTING.md`.
+- Use `CONTEXT.md` vocabulary (Model catalog, Snapshot, Auto-registration, Deals
+  catalog, Deals intelligence, Core, Display name); don't drift to the "avoid"
+  synonyms listed there.
+
 ## Agent skills
 
 ### Releases
 
 When the user asks to cut a release — "release", "bump to X", "tag vX.Y.Z" —
-the `release` project skill (`.pi/skills/release/`) is the trigger: version
-bump + CHANGELOG entry + snapshot refresh + tag, then the pipeline
+the `release` project skill (`.opencode/skills/release/`) is the trigger:
+version bump + CHANGELOG entry + snapshot refresh + tag, then the pipeline
 (`.github/workflows/release.yml`, ADR 0002) publishes to npm and creates the
 GitHub Release.
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,20 @@ A provider and plugin for [OpenCode](https://opencode.ai) that connects to the [
 ## Install
 
 ```sh
-opencode plugin add opencode-cmd-provider
+opencode plugin opencode-cmd-provider
 ```
 
-One command gives both `provider.commandcode` (auto-registered `[CMD]` models)
-and the Deals intelligence sidebar — it writes both `opencode.json(c)`
-(`server` target) and `tui.json` (`tui` target, `package.json`
-`exports["./tui"]` → `dist/tui.js`) from the same spec. No hand-written
-`tui.json` — bare `opencode` shows the Deals intelligence sidebar on next
-launch.
+Update an existing install:
+
+```sh
+opencode plugin opencode-cmd-provider --force
+```
+
+Install globally (available in every project):
+
+```sh
+opencode plugin opencode-cmd-provider --global
+```
 
 Manual config also works:
 
@@ -30,30 +35,7 @@ Manual config also works:
 }
 ```
 
-That's it. The plugin bundles a snapshot of the Command Code model catalog and
-auto-registers the `commandcode` provider — npm package, name, API key env var,
-and every model — when OpenCode loads. No `provider.commandcode` block, no
-`models` map, no network access needed. All Command Code models appear in
-`/models` with the `[CMD]` display-name prefix (e.g. `[CMD] Claude Sonnet 5`) so
-they aren't confused with same-named models from other providers.
-
-You can still declare your own `provider.commandcode` entry to customize
-behavior; your declarations always win and the snapshot fills in only what's
-missing:
-
-- Declared provider-level settings (`name`, `options`, `baseURL`, `env`) are
-  kept as you wrote them.
-- Declared models stay exactly as you wrote them — the snapshot never modifies
-  or removes them, and models that left the catalog remain usable.
-- `whitelist`/`blacklist` on a declared entry filter the auto-registered models
-  too, keeping the picker uncluttered.
-
-The catalog snapshot is refreshed at every release; newly published Command
-Code models appear after a plugin update. A second bundled catalog
-(`src/deals/catalog.ts`) carries deal/allowance/benchmark intelligence scraped
-from the Command Code docs — see below.
-
-Start or reload OpenCode, then authenticate:
+Then authenticate:
 
 ```txt
 /connect
@@ -114,11 +96,40 @@ Pick a model with `/models`, or run non-interactively:
 opencode run --model commandcode/claude-sonnet-5 "hello"
 ```
 
+## Deals intelligence
+
+Every Command Code model ships with deal/allowance/benchmark intelligence
+(bundled in `src/deals/catalog.ts`), scraped from the Command Code docs. It
+surfaces in two places:
+
+- **Sidebar** — in a session, the OpenCode sidebar (`ctrl+x b`) shows a
+  `Command Code` section for the selected model: tier, GOAT/Pro allowance,
+  benchmark (intelligence, tok/s), deal discounts (`was`/`now` rates), and
+  peak/off-peak windows.
+- **`cmd_plan_summary` tool** — plan-aware allowances and deal rates, to
+  estimate monthly requests.
+
+Delivery is zero-step: the package exports both a `server` and a `tui` target
+(`exports["./tui"]` → `dist/tui.js`), and `opencode plugin
+opencode-cmd-provider` writes both `opencode.json(c)` and `tui.json` from one
+spec. The sidebar is a TUI plugin loaded from `tui.json` — which is why
+installs made before the `./tui` export only wrote the server target and never
+showed a sidebar. Re-run with `--force` to add `tui.json`.
+
+When the Deals catalog is empty (scraping mitigated), the feature degrades
+visibly rather than silently: the sidebar shows a `Deals unavailable` banner
+with placeholder rows, and `cmd_plan_summary` reports that no deal data is
+bundled. Core (models, auth, streaming) is unaffected.
+
 ## Model discovery and offline behavior
 
 The plugin ships two bundled catalogs and auto-registers every model into
-OpenCode's config at startup. Model availability changes when the package is
-updated.
+OpenCode's config at startup, with the `[CMD]` display-name prefix (e.g.
+`[CMD] Claude Sonnet 5`) so they aren't confused with same-named models from
+other providers. Model availability changes when the package is updated. You
+can still declare your own `provider.commandcode` entry; your declarations
+always win and the snapshot fills in only what's missing (`whitelist`/
+`blacklist` on a declared entry filter the auto-registered models too).
 
 - Snapshot — `src/catalog/snapshot.ts` (model ids, names, context lengths) plus
   `src/catalog/facts.ts` (reasoning efforts, per-1M-token rates, input

--- a/docs/adr/0004-deals-intelligence-slice.md
+++ b/docs/adr/0004-deals-intelligence-slice.md
@@ -6,7 +6,7 @@ Deals intelligence (catalog `src/deals/catalog.ts` + enrichment `src/deals/enric
 
 Failure is visible: enrichment injects `model.options.cmd.unavailable=true` when `MODEL_DEALS` is empty, TUI renders banner `Deals unavailable — https://commandcode.ai/docs/resources/pricing-limits` plus placeholder rows (`Tier: —`), and `cmd_plan_summary` renders `No deal data is bundled…`. Sidebar previously hid silently (`<Show when={rows.length>0}>`).
 
-Delivery is zero-step: `package.json` exports `".": "./dist/index.js"` and `"./tui": "./dist/tui.js"`; `opencode plugin add opencode-cmd-provider` detects `server + tui targets` and writes both `opencode.json(c)` and `tui.json` from one spec. Hand-editing `opencode.json` alone is not supported — installer is the path. A single-file proxy (`default:{server,tui}`) is rejected by 1.18.19 (`tui?:never` / `server?:never` validated at import), so two files remain but one install gives both.
+Delivery is zero-step: `package.json` exports `".": "./dist/index.js"` and `"./tui": "./dist/tui.js"`; `opencode plugin opencode-cmd-provider` detects `server + tui targets` and writes both `opencode.json(c)` and `tui.json` from one spec. Hand-editing `opencode.json` alone is not supported — installer is the path. A single-file proxy (`default:{server,tui}`) is rejected by 1.18.19 (`tui?:never` / `server?:never` validated at import), so two files remain but one install gives both.
 
 ## Considered Options
 
@@ -17,5 +17,5 @@ Delivery is zero-step: `package.json` exports `".": "./dist/index.js"` and `"./t
 ## Consequences
 
 - `src/deals/` is the deep module boundary; deleting it plus two lines in `src/plugin/index.ts` (enrichment + tool registration) leaves core green.
-- `tui.json` is not hand-written by users; docs and README point to `opencode plugin add`.
+- `tui.json` is not hand-written by users; docs and README point to `opencode plugin`.
 - Published 1.1.1 omitted `./tui` export, so `opencode plugin` only wrote server target — next release must include it.

--- a/tests/plugin-install.test.ts
+++ b/tests/plugin-install.test.ts
@@ -1,5 +1,5 @@
 // tests/plugin-install.test.ts — verifies zero-step delivery:
-// `opencode plugin add <pkg>` detects server + tui targets from
+// `opencode plugin <pkg>` detects server + tui targets from
 // package.json exports["./tui"] and writes both opencode.json(c) and tui.json
 // with the same spec. Uses a local file:// spec so it runs without network
 // and without publishing.
@@ -13,7 +13,7 @@ const hasOpenCode = spawnSync("which", ["opencode"]).status === 0
 
 run([
   [
-    "opencode plugin add file://<pkg> creates both opencode.json and tui.json with same spec",
+    "opencode plugin file://<pkg> creates both opencode.json and tui.json with same spec",
     () => {
       if (!hasOpenCode) {
         console.log("skip - opencode not on PATH")
@@ -38,7 +38,7 @@ run([
         encoding: "utf-8",
         timeout: 30_000,
       })
-      assertEqual(result.status, 0, `opencode plugin add failed: ${result.stderr || result.stdout}`)
+      assertEqual(result.status, 0, `opencode plugin failed: ${result.stderr || result.stdout}`)
 
       // Installer writes to <proj>/.opencode/* when inside a project dir
       const serverPath = join(proj, ".opencode", "opencode.json")


### PR DESCRIPTION
Documentation and agent-guidance cleanup following the #39 Deals-intelligence work.

- **Fix the install command** — `opencode plugin add` → `opencode plugin` (there is no `add` subcommand on opencode 1.18). Fixed in README, ADR-0004, and the `plugin-install` test labels.
- **Simplify the Install section** — now purely installation: new install, update (`--force`), global (`--global`), and manual config. No prose about `tui.json`/catalogs/deals.
- **New `Deals intelligence` section** — moves the sidebar, `cmd_plan_summary`, zero-step `server`/`tui` delivery, and visible-degradation details out of Install.
- **AGENTS.md** — add build/test/architecture guidance agents would otherwise miss: bun required for the TUI build, single-test invocation, `test:unit` registration, the deliberate e2e skip, generated files, the two-host server/tui split, and the excisable Deals slice. Fix the release-skill path.