### PR TITLE
fix: 1.2.1 — restore /connect auto-registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ fixtures/empty catalog with a warning, so it can't block release.
   registration lines in `src/plugin/index.ts` leaves Core green. Keep the server
   barrel `src/deals/index.ts` free of the TUI re-exports — exporting `tui.tsx`
   from it pulls `solid-js`/`@opentui` into the server bundle.
+- **Never runtime-import `@opencode-ai/*`.** `@opencode-ai/plugin`/`@opencode-ai/sdk`
+  are optional peer deps: `opencode plugin <pkg>` installs them in `.opencode/`,
+  not next to the plugin, so a runtime import fails to resolve at load and kills
+  the whole plugin (no auto-registration, no `/connect`). Reference them only via
+  `import type`. Enforced by `tests/contract.test.ts`.
 - The install command is `opencode plugin <pkg>` — **there is no `add`
   subcommand** on opencode 1.18+.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.2.1 - 2026-08-21
+
+Fix: `/connect` no longer lists Command Code — the plugin failed to load.
+
+- The `cmd_plan_summary` tool runtime-imported `@opencode-ai/plugin`, an
+  optional peer dependency that `opencode plugin <pkg>` installs in
+  `.opencode/`, not next to the plugin. That import threw `ERR_MODULE_NOT_FOUND`
+  at load, silently killing the whole server plugin — no auto-registration and
+  no `/connect` entry (Command Code vanished from the provider list).
+- The tool now builds its Zod args from a direct `zod` dependency instead of
+  `@opencode-ai/plugin`'s `tool()` helper, so the server bundle has zero
+  runtime imports of optional peers.
+- Added a contract test that scans the built `dist/` and fails on any runtime
+  `@opencode-ai/*` import, so this class of regression can't ship again.
+
 ## 1.2.0 - 2026-08-21
 
 Feature: Deals intelligence — per-model pricing/allowance data in a sidebar panel and a plan-summary tool, delivered zero-step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@ai-sdk/provider": "^4.0.7",
         "@opentui/core": "^0.5.4",
         "@opentui/solid": "^0.5.4",
-        "solid-js": "1.9.12"
+        "solid-js": "1.9.12",
+        "zod": "^4.1.8"
       },
       "devDependencies": {
         "@opencode-ai/plugin": "*",
@@ -2762,7 +2763,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
       "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@ai-sdk/provider": "^4.0.7",
     "@opentui/core": "^0.5.4",
     "@opentui/solid": "^0.5.4",
-    "solid-js": "1.9.12"
+    "solid-js": "1.9.12",
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/deals/plan-summary.ts
+++ b/src/deals/plan-summary.ts
@@ -2,7 +2,7 @@
 // breakdown. Plan resolution: tool arg → COMMANDCODE_PLAN → live /alpha/whoami
 // (when a key is present and the network works) → default "go". Rendering is a
 // pure function so tests never touch the network.
-import { tool } from "@opencode-ai/plugin"
+import { z } from "zod"
 import { MODEL_COSTS } from "../catalog/facts.js"
 import {
   MODEL_DEALS,
@@ -173,12 +173,12 @@ function estimateMonthlyRequests(modelId: string, allowance: number): number {
 }
 
 export function planSummaryTool() {
-  return tool({
+  return {
     description:
       "Show the Command Code plan's credits, usage windows, per-model monthly allowances (GOAT/Pro) or active deals (other plans), with estimated monthly request counts. Set COMMANDCODE_PLAN (go|goat|pro|max|max20|teampro|provider) to pin the plan without network access.",
     args: {
-      plan: tool.schema.string().optional().describe("go|goat|pro|max|max20|teampro|provider"),
+      plan: z.string().optional().describe("go|goat|pro|max|max20|teampro|provider"),
     },
-    execute: async (args) => renderPlanSummary(await resolvePlan(args.plan)),
-  })
+    execute: async (args: { plan?: string }) => renderPlanSummary(await resolvePlan(args.plan)),
+  }
 }

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -1,5 +1,7 @@
 // tests/contract.test.ts
 import { createRequire } from "node:module"
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
 import { run, assert, assertEqual } from "./harness.js"
 
 const require = createRequire(import.meta.url)
@@ -17,6 +19,19 @@ async function load(): Promise<Record<string, unknown>> {
 async function loadTui(): Promise<Record<string, unknown>> {
   const mod = await import("../dist/tui.js")
   return mod as Record<string, unknown>
+}
+
+function listJsFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const file = join(dir, entry)
+    if (statSync(file).isDirectory()) {
+      out.push(...listJsFiles(file))
+    } else if (entry.endsWith(".js")) {
+      out.push(file)
+    }
+  }
+  return out
 }
 
 run([
@@ -78,6 +93,28 @@ run([
       assert(typeof def === "object" && def !== null)
       assertEqual(def.id, "commandcode")
       assert(typeof def.server === "function")
+    },
+  ],
+  [
+    "built bundle has no runtime imports of optional peer deps (@opencode-ai/*)",
+    () => {
+      // A runtime `import ... from "@opencode-ai/*"` in the published bundle is a
+      // load-time landmine: `@opencode-ai/plugin` is an optional peer dependency,
+      // so `opencode plugin <pkg>` does not install it next to the plugin and the
+      // whole server plugin fails to import (ERR_MODULE_NOT_FOUND) — which silently
+      // drops auto-registration and /connect. Only `import type` (erased by tsc/bun)
+      // may reference these packages.
+      const offenders: string[] = []
+      for (const file of listJsFiles(new URL("../dist", import.meta.url).pathname)) {
+        const text = readFileSync(file, "utf-8")
+        if (/^\s*import\s.*from\s+["']@opencode-ai\//m.test(text)) {
+          offenders.push(file)
+        }
+      }
+      assert(
+        offenders.length === 0,
+        `runtime @opencode-ai/* imports found in built bundle: ${offenders.join(", ")}`,
+      )
     },
   ],
 ])


### PR DESCRIPTION
## Summary

`v1.2.0` regressed `/connect`: "Command Code" no longer appeared in the provider list, and models weren't auto-registered. Root cause: the `cmd_plan_summary` tool runtime-imported `@opencode-ai/plugin` (an optional peer dependency that `opencode plugin <pkg>` does not install next to the plugin), so the whole server plugin failed to load with `ERR_MODULE_NOT_FOUND`.

## Changes

- `src/deals/plan-summary.ts`: build the tool's Zod args from a direct `zod` dependency instead of `@opencode-ai/plugin`'s `tool()` helper.
- `package.json`: add `zod` as a runtime dependency.
- `tests/contract.test.ts`: contract test that fails on any runtime `@opencode-ai/*` import in the built `dist/`.
- `AGENTS.md`: document the "never runtime-import `@opencode-ai/*`" constraint.

## Verification

- `npm test` — 192 ok, 0 fail.
- Reproduced the failure first (`opencode plugin opencode-cmd-provider@1.2.0` → `opencode models` returned 0 commandcode models), then confirmed the fix (packed + `--omit=dev` install → 57 models, `commandcode | Command Code` in `/provider`).