### PR TITLE
chore(release): 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.2 - 2026-08-22
+
+Chore: catalog refresh to `command-code@1.32.1`.
+
+- Added `deepseek/deepseek-v4-flash-vision-exp` (DeepSeek V4 Flash Vision (exp)):
+  1M context, text+image input, reasoning efforts `high`/`max`, $0.22/$0.66 per
+  1M input/output tokens.
+- Added reasoning efforts for `stealth/ox-alpha` (`low`, `high`, `max`).
+- Deals catalog unchanged (56 entries).
+
 ## 1.2.1 - 2026-08-21
 
 Fix: `/connect` no longer lists Command Code — the plugin failed to load.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-cmd-provider",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/catalog/facts.ts
+++ b/src/catalog/facts.ts
@@ -5,18 +5,20 @@
 // modalities parsed from its CLI bundle (dist/cli.mjs). Regenerate
 // with `npm run refresh:snapshot`.
 
-export const FACTS_SOURCE_URL = "https://unpkg.com/command-code@1.31.0/dist/bundled/command-code-knowledge/reference/models.md"
-export const MODALITIES_SOURCE_URL = "https://unpkg.com/command-code@1.31.0/dist/cli.mjs"
-export const FACTS_PACKAGE_VERSION = "1.31.0"
-export const FACTS_LAST_REFRESHED = "2026-08-21"
+export const FACTS_SOURCE_URL = "https://unpkg.com/command-code@1.32.1/dist/bundled/command-code-knowledge/reference/models.md"
+export const MODALITIES_SOURCE_URL = "https://unpkg.com/command-code@1.32.1/dist/cli.mjs"
+export const FACTS_PACKAGE_VERSION = "1.32.1"
+export const FACTS_LAST_REFRESHED = "2026-08-22"
 
 export const MODEL_EFFORTS: Readonly<Record<string, readonly string[]>> = {
   "deepseek/deepseek-v4-pro": ["high","max"],
   "deepseek/deepseek-v4-flash": ["high","max"],
+  "deepseek/deepseek-v4-flash-vision-exp": ["high","max"],
   "zai-org/GLM-5.3": ["low","high","max"],
   "zai-org/GLM-5.2": ["high","max"],
   "Qwen/Qwen3.8-Max": ["low","medium","xhigh"],
   "Qwen/Qwen3.8-27B": ["low","medium","xhigh"],
+  "stealth/ox-alpha": ["low","high","max"],
   "claude-sonnet-5": ["low","medium","high","xhigh","max"],
   "claude-sonnet-4-6": ["low","medium","high","xhigh","max"],
   "claude-fable-5": ["low","medium","high","xhigh","max"],
@@ -45,6 +47,7 @@ export const MODEL_COSTS: Readonly<
 > = {
   "deepseek/deepseek-v4-pro": { input: 0.66, output: 1.98, cacheRead: 0.022, cacheWrite: 0 },
   "deepseek/deepseek-v4-flash": { input: 0.22, output: 0.66, cacheRead: 0.007, cacheWrite: 0 },
+  "deepseek/deepseek-v4-flash-vision-exp": { input: 0.22, output: 0.66, cacheRead: 0.01, cacheWrite: 0 },
   "moonshotai/Kimi-K3": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
   "moonshotai/Kimi-K2.7-Code": { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
   "moonshotai/Kimi-K2.7-Code-Highspeed": { input: 1.9, output: 8, cacheRead: 0.38, cacheWrite: 0 },
@@ -118,6 +121,7 @@ export const MODEL_INPUT_MODALITIES: Readonly<
   "claude-opus-5": ["text","image"],
   "claude-sonnet-4-6": ["text","image"],
   "claude-sonnet-5": ["text","image"],
+  "deepseek/deepseek-v4-flash-vision-exp": ["text","image"],
   "google/gemini-3.1-flash-lite": ["text","image"],
   "google/gemini-3.5-flash": ["text","image"],
   "google/gemini-3.5-flash-lite": ["text","image"],

--- a/src/catalog/snapshot.ts
+++ b/src/catalog/snapshot.ts
@@ -27,6 +27,7 @@ export const MODEL_SNAPSHOT: readonly CatalogModel[] = [
   { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", contextLength: 400000 },
   { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro (latest)", contextLength: 1000000 },
   { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash (latest)", contextLength: 1000000 },
+  { id: "deepseek/deepseek-v4-flash-vision-exp", name: "DeepSeek V4 Flash Vision (exp)", contextLength: 1000000 },
   { id: "moonshotai/Kimi-K3", name: "Kimi K3", contextLength: 1000000 },
   { id: "moonshotai/Kimi-K2.7-Code", name: "Kimi K2.7 Code", contextLength: 256000 },
   { id: "moonshotai/Kimi-K2.7-Code-Highspeed", name: "Kimi K2.7 Code HighSpeed", contextLength: 262000 },

--- a/src/deals/catalog.ts
+++ b/src/deals/catalog.ts
@@ -111,5 +111,5 @@ export const PLAN_CATALOG: Readonly<Record<PlanId, PlanInfo>> = {
 }
 
 export const DEAL_SOURCE_URL = "https://commandcode.ai/docs/resources/pricing-limits"
-export const DEAL_LAST_REFRESHED = "2026-08-21"
+export const DEAL_LAST_REFRESHED = "2026-08-22"
 export const DEAL_PACKAGE_VERSION = "docs"

--- a/tests/catalog-metadata.test.ts
+++ b/tests/catalog-metadata.test.ts
@@ -44,6 +44,7 @@ const NON_REASONING_MODELS = new Set([
 const EFFORTS_MODELS = new Set([
   "deepseek/deepseek-v4-pro",
   "deepseek/deepseek-v4-flash",
+  "deepseek/deepseek-v4-flash-vision-exp",
   "zai-org/GLM-5.3",
   "zai-org/GLM-5.2",
   "Qwen/Qwen3.8-Max",


### PR DESCRIPTION
Catalog refresh to command-code@1.32.1 + version bump.

- Added `deepseek/deepseek-v4-flash-vision-exp` (DeepSeek V4 Flash Vision (exp)): 1M context, text+image input, efforts `high`/`max`, $0.22/$0.66 per 1M in/out
- Added reasoning efforts for `stealth/ox-alpha` (`low`, `high`, `max`)
- Deals catalog unchanged (56 entries)
- package-lock regenerated via `npm install --package-lock-only`