### PR TITLE
feat(models): configurable display-name prefix for auto-registered models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,16 @@ Feature: dual-transport Provider API — non-Go plans now use the documented
 - New test suites: provider transport, parity, upgrade-fallback, ZDR, and
   deals coverage — all wired into `test:unit`.
 
+## Unreleased
+
+Feature: configurable display-name prefix for auto-registered models
+([#60](https://github.com/rashidrazak/opencode-cmd-provider/issues/60)).
+
+- Set `provider.commandcode.options.display_prefix` to a string to replace the
+  default `[CMD] ` prefix; an empty string disables the prefix entirely.
+- Declared model entries are unaffected; the prefix only applies to models
+  auto-registered from the bundled snapshot.
+
 ## 1.2.2 - 2026-08-22
 
 Chore: catalog refresh to `command-code@1.32.1`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,7 +25,7 @@ Updating the snapshot to match the live model catalog; happens on plugin release
 _Avoid_: model sync, catalog update, live refresh
 
 **Core**:
-`provider.commandcode` auto-registration (snapshot → `provider.commandcode.models`), `[CMD]` display names, `COMMANDCODE_API_KEY` auth, and `provider/*` streaming. Deals intelligence is not part of core.
+`provider.commandcode` auto-registration (snapshot → `provider.commandcode.models`), configurable display-name prefix (default `[CMD]`), `COMMANDCODE_API_KEY` auth, and `provider/*` streaming. Deals intelligence is not part of core.
 _Avoid_: base provider, essential plugin
 
 **Deals catalog**:
@@ -48,5 +48,5 @@ A versioned publication of the package: a git tag `vX.Y.Z` matching the `package
 _Avoid_: publish, deploy, ship (when meaning the whole publication)
 
 **Display name**:
-The name shown for a model in OpenCode's picker: the raw catalog name with the `[CMD]` prefix (`[CMD] Claude Sonnet 5`).
+The name shown for a model in OpenCode's picker: the raw catalog name with the configurable display prefix (default `[CMD]`, e.g. `[CMD] Claude Sonnet 5`; `provider.commandcode.options.display_prefix` overrides it, empty string disables).
 _Avoid_: label, model name, pretty name

--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ can still declare your own `provider.commandcode` entry; your declarations
 always win and the snapshot fills in only what's missing (`whitelist`/
 `blacklist` on a declared entry filter the auto-registered models too).
 
+The `[CMD] ` display-name prefix is configurable through the declared
+provider entry's options:
+
+```jsonc
+{
+  "provider": {
+    "commandcode": {
+      "options": {
+        "display_prefix": "", // default "[CMD] "; empty string disables
+      },
+    },
+  },
+}
+```
+
+Declared model entries are never renamed; the prefix applies to
+auto-registered models only.
+
 - Snapshot — `src/catalog/snapshot.ts` (model ids, names, context lengths) plus
   `src/catalog/facts.ts` (reasoning efforts, per-1M-token rates, input
   modalities). Regenerated from the live catalog via `npm run refresh:snapshot`.

--- a/docs/adr/0001-auto-registration-snapshot.md
+++ b/docs/adr/0001-auto-registration-snapshot.md
@@ -30,7 +30,7 @@ during the `config` hook, which OpenCode runs before it parses `config.provider`
 - Auto-registration merges with user declarations: user entries and provider-level keys
   win, snapshot fills only what's missing; `whitelist`/`blacklist` still filter snapshot
   models.
-- Model display names use the `[CMD]` prefix (`[CMD] Claude Sonnet 5`).
+- Model display names use a configurable prefix (default `[CMD]`; `options.display_prefix` on the declared entry overrides it, empty string disables).
 - The registered entry declares `env: ["COMMANDCODE_API_KEY"]`, so setting the env var
   marks the provider connected in `/models`.
 - With no opt-out, users control picker clutter via `whitelist`/`blacklist` on a declared

--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,9 +1147,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,9 +1172,6 @@
       "integrity": "sha512-YYREqUB3v5K0qWij3A5YWzJkkVXp/EqIiuHZKsAjrUAY/0+Bp8Hn0baLvvvkuklpG9whW+GfwIeUsmp4fxqmCA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/plugin/models.ts
+++ b/src/plugin/models.ts
@@ -6,9 +6,21 @@ import { reasoningVariantsForModel, isReasoningModel } from "../provider/reasoni
 import { inputModalitiesForModel } from "../provider/modalities.js"
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 65_536
+export const DEFAULT_DISPLAY_PREFIX = "[CMD] "
 
 type ConfigModel = NonNullable<NonNullable<ProviderConfig["models"]>[string]>
 type ConfigVariants = NonNullable<ConfigModel["variants"]>
+
+/**
+ * Resolves the auto-registration display-name prefix from the user-declared
+ * `provider.commandcode.options.display_prefix` key. A string value is used
+ * verbatim (empty string disables the prefix); anything else falls back to
+ * `[CMD] `. Read-only: never persisted into the user's config.
+ */
+export function resolveDisplayPrefix(entry: ProviderConfig | undefined): string {
+  const value = entry?.options?.display_prefix
+  return typeof value === "string" ? value : DEFAULT_DISPLAY_PREFIX
+}
 
 export interface AutoRegisterOptions {
   npm: string
@@ -35,6 +47,9 @@ export interface AutoRegisterOptions {
  *   config key or by the entry's `id`);
  * - declared models are never modified, and declared models that left the
  *   catalog stay usable.
+ * - `options.display_prefix` (string) overrides the default `[CMD] `
+ *   display-name prefix for auto-registered models; an empty string disables
+ *   the prefix.
  */
 export function autoRegister(
   config: Config,
@@ -52,6 +67,7 @@ export function autoRegister(
   entry.options.baseURL ??= options.baseURL
   entry.models ??= {}
 
+  const prefix = resolveDisplayPrefix(entry)
   const declaredById = new Set(
     Object.values(entry.models)
       .map((model) => model?.id)
@@ -60,7 +76,7 @@ export function autoRegister(
 
   for (const model of snapshot) {
     if (entry.models[model.id] !== undefined || declaredById.has(model.id)) continue
-    entry.models[model.id] = configModelFor(model)
+    entry.models[model.id] = configModelFor(model, prefix)
   }
   return config
 }
@@ -92,15 +108,15 @@ export function augmentConfigCommandCodeModels(config: Config): void {
 
 /**
  * Config-schema model entry (not the SDK `Model` shape) for a snapshot model:
- * `[CMD]`-prefixed display name, context/output limits with output capped at
+ * prefixed display name, context/output limits with output capped at
  * 65_536, and metadata enriched from the reasoning, modality, and pricing
  * tables.
  */
-function configModelFor(model: CatalogModel): ConfigModel {
+function configModelFor(model: CatalogModel, prefix = DEFAULT_DISPLAY_PREFIX): ConfigModel {
   const variants = reasoningVariantsForModel(model.id)
   const costs: CommandCodeModelCost = MODEL_COSTS[model.id] ?? ZERO_MODEL_COST
   return {
-    name: `[CMD] ${model.name}`,
+    name: `${prefix}${model.name}`,
     limit: {
       context: model.contextLength,
       output: Math.min(model.contextLength, DEFAULT_MAX_OUTPUT_TOKENS),

--- a/tests/plugin-models.test.ts
+++ b/tests/plugin-models.test.ts
@@ -1,6 +1,11 @@
 // tests/plugin-models.test.ts — snapshot auto-registration + config augmentation
 // (issue #16)
-import { autoRegister, augmentConfigCommandCodeModels } from "../src/plugin/models.js"
+import {
+  autoRegister,
+  augmentConfigCommandCodeModels,
+  DEFAULT_DISPLAY_PREFIX,
+  resolveDisplayPrefix,
+} from "../src/plugin/models.js"
 import type { CatalogModel } from "../src/catalog/snapshot.js"
 import { assert, assertEqual, run } from "./harness.js"
 
@@ -161,6 +166,81 @@ run([
       assertEqual(entry.npm, "opencode-cmd-provider")
       assertEqual(entry.env, ["COMMANDCODE_API_KEY"])
       assertEqual(entry.options, { baseURL: "https://api.commandcode.ai" })
+    },
+  ],
+
+  [
+    "resolveDisplayPrefix falls back to the [CMD] default",
+    () => {
+      assertEqual(DEFAULT_DISPLAY_PREFIX, "[CMD] ")
+      assertEqual(resolveDisplayPrefix(undefined), "[CMD] ")
+      assertEqual(resolveDisplayPrefix({}), "[CMD] ")
+      assertEqual(resolveDisplayPrefix({ options: {} }), "[CMD] ")
+      assertEqual(resolveDisplayPrefix({ options: { display_prefix: 42 } }), "[CMD] ")
+    },
+  ],
+
+  [
+    "display_prefix overrides auto-registered model names",
+    () => {
+      const config = {
+        provider: {
+          commandcode: {
+            options: { display_prefix: "CC/" },
+          },
+        },
+      }
+      autoRegister(config, SNAPSHOT, OPTIONS)
+      const entry = config.provider.commandcode
+      assertEqual(entry.models["claude-sonnet-5"].name, "CC/Claude Sonnet 5")
+      assertEqual(entry.models["unknown/foo"].name, "CC/Foo")
+    },
+  ],
+
+  [
+    "an empty display_prefix disables the prefix entirely",
+    () => {
+      const config = {
+        provider: {
+          commandcode: {
+            options: { display_prefix: "" },
+          },
+        },
+      }
+      autoRegister(config, SNAPSHOT, OPTIONS)
+      const entry = config.provider.commandcode
+      assertEqual(entry.models["claude-sonnet-5"].name, "Claude Sonnet 5")
+      assertEqual(entry.models["deepseek/deepseek-v4-flash"].name, "DeepSeek V4 Flash (latest)")
+      // Non-name metadata must be unaffected.
+      assertEqual(entry.models["claude-sonnet-5"].limit, { context: 200000, output: 65536 })
+      assertEqual(entry.models["claude-sonnet-5"].reasoning, true)
+    },
+  ],
+
+  [
+    "declared models keep their names; empty prefix also applies to auto-registered ones",
+    () => {
+      const declared = {
+        "my-sonnet": {
+          id: "claude-sonnet-5",
+          name: "My Sonnet",
+          limit: { context: 999, output: 999 },
+        },
+      }
+      const config = {
+        provider: {
+          commandcode: {
+            options: { display_prefix: "" },
+            models: declared,
+          },
+        },
+      }
+      autoRegister(config, SNAPSHOT, OPTIONS)
+      const entry = config.provider.commandcode
+      // Declared entries are preserved verbatim.
+      assertEqual(entry.models["my-sonnet"], declared["my-sonnet"])
+      // The empty prefix applies to auto-registered models.
+      assertEqual(entry.models["unknown/foo"].name, "Foo")
     },
   ],
 


### PR DESCRIPTION
Closes #60.

## What

Auto-registered models currently hardcode the `[CMD] ` display-name prefix. This PR makes it configurable through the declared provider entry's options:

```jsonc
{
  "provider": {
    "commandcode": {
      "options": {
        "display_prefix": "" // default "[CMD] "; empty string disables
      }
    }
  }
}
```

- Default behavior is unchanged (`[CMD] `).
- A string value is used verbatim; an empty string disables the prefix.
- Non-string values fall back to the default.
- Declared model entries are never renamed — the prefix only applies to models auto-registered from the bundled snapshot.
- The option is read-only at resolution time; nothing is persisted into the user's config (unlike `npm`/`name`/`env`/`options.baseURL`, which are filled when unset).

## Why `options.display_prefix`

`ProviderConfig.options` is the one place in the SDK type with an index signature, so this stays type-safe without widening upstream types. It also sits naturally next to `baseURL`.

## Tests

Four new cases in `tests/plugin-models.test.ts`:

- `resolveDisplayPrefix` fallback behavior (`undefined` entry, missing options, non-string value)
- prefix override (`"CC/"`)
- empty string disables the prefix (and non-name metadata is unaffected)
- declared models keep their names regardless of the setting

## Gates

`npm run build`, `npm test`, `npm run typecheck`, `npm run format:check`, and `git diff --check` all pass.