### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.5.0 - 2026-08-23
+
+Feature: the `[CMD] ` display-name prefix for auto-registered models is now
+configurable via `provider.commandcode.options.display_prefix`.
+
+### Features
+
+- **Configurable display-name prefix** (issue #60): a string value replaces the
+  default `[CMD] ` prefix, and an empty string disables it entirely. The option
+  is read-only at resolution time — nothing is persisted into the user's config
+  (unlike `npm`/`name`/`env`/`options.baseURL`, which are filled when unset).
+- Non-string values fall back to the default `[CMD] ` prefix.
+- Declared model entries are never renamed — the prefix applies only to models
+  auto-registered from the bundled snapshot.
+
+### Chores
+
+- New `tests/plugin-models.test.ts` cases: `resolveDisplayPrefix` fallback,
+  prefix override (`"CC/"`), empty string disabling the prefix (with non-name
+  metadata unaffected), and declared models keeping their names regardless of
+  the setting.
+
 ## 1.4.0 - 2026-08-23
 
 Feature: after a successful `/connect`, the credential is mirrored under
@@ -76,16 +98,6 @@ Feature: dual-transport Provider API — non-Go plans now use the documented
   (`npm run refresh` from `tests/fixtures/*.html`).
 - New test suites: provider transport, parity, upgrade-fallback, ZDR, and
   deals coverage — all wired into `test:unit`.
-
-## Unreleased
-
-Feature: configurable display-name prefix for auto-registered models
-([#60](https://github.com/rashidrazak/opencode-cmd-provider/issues/60)).
-
-- Set `provider.commandcode.options.display_prefix` to a string to replace the
-  default `[CMD] ` prefix; an empty string disables the prefix entirely.
-- Declared model entries are unaffected; the prefix only applies to models
-  auto-registered from the bundled snapshot.
 
 ## 1.2.2 - 2026-08-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-cmd-provider",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/catalog/facts.ts
+++ b/src/catalog/facts.ts
@@ -8,7 +8,7 @@
 export const FACTS_SOURCE_URL = "https://unpkg.com/command-code@1.32.1/dist/bundled/command-code-knowledge/reference/models.md"
 export const MODALITIES_SOURCE_URL = "https://unpkg.com/command-code@1.32.1/dist/cli.mjs"
 export const FACTS_PACKAGE_VERSION = "1.32.1"
-export const FACTS_LAST_REFRESHED = "2026-08-22"
+export const FACTS_LAST_REFRESHED = "2026-08-23"
 
 export const MODEL_EFFORTS: Readonly<Record<string, readonly string[]>> = {
   "deepseek/deepseek-v4-pro": ["high","max"],

--- a/src/deals/catalog.ts
+++ b/src/deals/catalog.ts
@@ -113,5 +113,5 @@ export const PLAN_CATALOG: Readonly<Record<PlanId, PlanInfo>> = {
 }
 
 export const DEAL_SOURCE_URL = "https://commandcode.ai/docs/resources/pricing-limits"
-export const DEAL_LAST_REFRESHED = "2026-08-22"
+export const DEAL_LAST_REFRESHED = "2026-08-23"
 export const DEAL_PACKAGE_VERSION = "docs"


### PR DESCRIPTION
## What

Release **1.5.0** (minor): configurable display-name prefix for auto-registered models (#66, fixes #60).

- Version bump `1.4.0` → `1.5.0` in `package.json` / `package-lock.json`.
- CHANGELOG: promotes `## Unreleased` to `## 1.5.0 - 2026-08-23` in the house style.
- Catalog refresh folded in: `facts.ts` / `deals.ts` date stamps → 2026-08-23 (release-gate ignores these).

## Gates

`npm run typecheck` ✓, `npm run test:unit` (282 tests) ✓, prettier ✓.