### PR TITLE
fix(stream): synthesize reasoning and text start/end lifecycle in provider parsers

### DIFF
--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -396,6 +396,10 @@ export function anthropicEventToStreamPart(event: unknown): LanguageModelV3Strea
       const id = `text-${index}`
       return [{ type: "text-start", id }]
     }
+    if (blockType === "thinking") {
+      const id = stringValue(block?.id) ?? `thinking-${index}`
+      return [{ type: "reasoning-start", id }]
+    }
     if (blockType === "tool_use") {
       const id = stringValue(block?.id) ?? `tool-${index}`
       const name = stringValue(block?.name) ?? ""
@@ -404,16 +408,33 @@ export function anthropicEventToStreamPart(event: unknown): LanguageModelV3Strea
     return []
   }
 
+  if (type === "content_block_delta") {
+    const delta = asRecord(event.delta)
+    const index = numberValue(event.index) ?? 0
+    const text = stringValue(delta?.text)
+    if (typeof text === "string" && text.length > 0) {
+      const id = `text-${index}`
+      return [{ type: "text-delta", id, delta: text }]
+    }
+    const thinking = stringValue(delta?.thinking)
+    if (typeof thinking === "string" && thinking.length > 0) {
+      const id = `thinking-${index}`
+      return [{ type: "reasoning-delta", id, delta: thinking }]
+    }
+    // Tool input delta: { type: "input_json_delta", partial_json: "..." }
+    const partial = stringValue(delta?.partial_json)
+    if (typeof partial === "string" && partial.length > 0) {
+      const id = `tool-${index}`
+      // Emit as tool-input-delta; caller may have started tool
+      return [{ type: "tool-input-delta", id, delta: partial }]
+    }
+    return []
+  }
+
   if (type === "content_block_stop") {
     // Stateless codec: the STOP event carries only `index`, not the block type.
-    // Anthropic streams either `text` or `tool_use` blocks; the AI SDK expects
-    // `text-end` for the former and `tool-input-end` for the latter. Emitting
-    // both is noisy (previous emitted two parts) but guarantees the right end
-    // is seen regardless of block type, and the consumer ignores the spurious
-    // one per AI SDK spec. Emit a single text-end here would break tool_use
-    // streams that rely on tool-input-end, so we keep the conservative pair
-    // with an explicit note referencing provider doc streaming (message_delta
-    // carries the final usage/finish; per-block ends are AI SDK concerns).
+    // Anthropic streams either `text`, `thinking` or `tool_use` blocks; the AI SDK expects
+    // `text-end` for text, `reasoning-end` for thinking, and `tool-input-end` for tool_use.
     const index = numberValue(event.index) ?? 0
     const idText = `text-${index}`
     const idTool = `tool-${index}`
@@ -485,6 +506,29 @@ export function createOpenAIStreamParser(): (event: unknown) => LanguageModelV3S
   // finish_reason here so the usage-only chunk's finish keeps the real reason
   // (e.g. "length") instead of defaulting to "stop".
   let lastFinishReason: LanguageModelV3FinishReason | undefined
+  let reasoningStarted = false
+  let reasoningEnded = false
+  let reasoningId: string | undefined
+  let textStarted = false
+  let textEnded = false
+  let textId: string | undefined
+
+  function closeReasoning(): LanguageModelV3StreamPart[] {
+    if (reasoningStarted && !reasoningEnded && reasoningId) {
+      reasoningEnded = true
+      return [{ type: "reasoning-end", id: reasoningId }]
+    }
+    return []
+  }
+
+  function closeText(): LanguageModelV3StreamPart[] {
+    if (textStarted && !textEnded && textId) {
+      textEnded = true
+      return [{ type: "text-end", id: textId }]
+    }
+    return []
+  }
+
   return (event) => {
     if (!isRecord(event)) return []
     // Error events flow through the stateless mapper (redacted throw).
@@ -494,17 +538,45 @@ export function createOpenAIStreamParser(): (event: unknown) => LanguageModelV3S
     const parts: LanguageModelV3StreamPart[] = []
     const choice = firstChoice(event)
     const delta = choice ? deltaFromChoice(choice) : undefined
+    const eventId = stringValue((event as Record<string, unknown>).id)
+
     if (delta) {
-      const content = stringValue(delta.content)
-      if (typeof content === "string" && content.length > 0) {
-        parts.push(textDeltaPart((event as Record<string, unknown>).id, content))
-      }
       const reasoning = stringValue(delta.reasoning) ?? stringValue(delta.reasoning_content)
       if (typeof reasoning === "string" && reasoning.length > 0) {
-        parts.push(reasoningDeltaPart((event as Record<string, unknown>).id, reasoning))
+        if (!reasoningStarted || reasoningEnded) {
+          if (textStarted && !textEnded) {
+            parts.push(...closeText())
+          }
+          reasoningStarted = true
+          reasoningEnded = false
+          reasoningId = eventId || "reasoning-0"
+          parts.push({ type: "reasoning-start", id: reasoningId })
+        }
+        parts.push(reasoningDeltaPart(reasoningId ?? eventId, reasoning))
       }
+
+      const content = stringValue(delta.content)
+      if (typeof content === "string" && content.length > 0) {
+        if (reasoningStarted && !reasoningEnded) {
+          parts.push(...closeReasoning())
+        }
+        if (!textStarted || textEnded) {
+          textStarted = true
+          textEnded = false
+          textId = eventId || "text-0"
+          parts.push({ type: "text-start", id: textId })
+        }
+        parts.push(textDeltaPart(textId ?? eventId, content))
+      }
+
       const toolCalls = delta.tool_calls ?? delta.toolCalls
       if (Array.isArray(toolCalls)) {
+        if (reasoningStarted && !reasoningEnded) {
+          parts.push(...closeReasoning())
+        }
+        if (textStarted && !textEnded) {
+          parts.push(...closeText())
+        }
         for (const tc of toolCalls) {
           if (!isRecord(tc)) continue
           const fn = isRecord(tc.function) ? tc.function : {}
@@ -560,6 +632,12 @@ export function createOpenAIStreamParser(): (event: unknown) => LanguageModelV3S
     const finishReason = finishReasonRaw ? mapFinishReason(finishReasonRaw) : undefined
     if (finishReason) lastFinishReason = finishReason
     if (lastFinishReason || hasUsage) {
+      if (reasoningStarted && !reasoningEnded) {
+        parts.push(...closeReasoning())
+      }
+      if (textStarted && !textEnded) {
+        parts.push(...closeText())
+      }
       // Flush any tool call whose terminal args chunk never arrived.
       for (const [index, buffer] of toolBuffers) {
         if (buffer.started && !buffer.emitted) {
@@ -584,6 +662,7 @@ export function createOpenAIStreamParser(): (event: unknown) => LanguageModelV3S
 
 export function createAnthropicStreamParser(): (event: unknown) => LanguageModelV3StreamPart[] {
   const toolBlocks = new Map<number, ToolCallBuffer>()
+  const blockTypes = new Map<number, "text" | "tool_use" | "thinking">()
   return (event) => {
     if (!isRecord(event)) return []
     const type = stringValue(event.type)
@@ -592,12 +671,21 @@ export function createAnthropicStreamParser(): (event: unknown) => LanguageModel
       const index = numberValue(event.index) ?? 0
       const blockType = stringValue(block?.type)
       if (blockType === "tool_use") {
+        blockTypes.set(index, "tool_use")
         const id = stringValue(block?.id) ?? `tool-${index}`
         const name = stringValue(block?.name) ?? ""
         toolBlocks.set(index, { id, name, input: "", started: true, emitted: false })
         return [{ type: "tool-input-start", id, toolName: name }]
       }
-      if (blockType === "text") return [{ type: "text-start", id: `text-${index}` }]
+      if (blockType === "thinking") {
+        blockTypes.set(index, "thinking")
+        const id = stringValue(block?.id) ?? `thinking-${index}`
+        return [{ type: "reasoning-start", id }]
+      }
+      if (blockType === "text") {
+        blockTypes.set(index, "text")
+        return [{ type: "text-start", id: `text-${index}` }]
+      }
       return []
     }
     if (type === "content_block_delta") {
@@ -606,6 +694,10 @@ export function createAnthropicStreamParser(): (event: unknown) => LanguageModel
       const text = stringValue(delta?.text)
       if (typeof text === "string" && text.length > 0) {
         return [{ type: "text-delta", id: `text-${index}`, delta: text }]
+      }
+      const thinking = stringValue(delta?.thinking)
+      if (typeof thinking === "string" && thinking.length > 0) {
+        return [{ type: "reasoning-delta", id: `thinking-${index}`, delta: thinking }]
       }
       const partial = stringValue(delta?.partial_json)
       if (typeof partial === "string" && partial.length > 0) {
@@ -639,6 +731,26 @@ export function createAnthropicStreamParser(): (event: unknown) => LanguageModel
     }
     if (type === "content_block_stop") {
       const index = numberValue(event.index) ?? 0
+      const bType = blockTypes.get(index)
+      blockTypes.delete(index)
+      if (bType === "tool_use") {
+        const block = toolBlocks.get(index)
+        if (block) {
+          toolBlocks.delete(index)
+          if (block.emitted) return []
+          return [
+            { type: "tool-input-end", id: block.id },
+            {
+              type: "tool-call",
+              toolCallId: block.id,
+              toolName: block.name,
+              input: block.input,
+            },
+          ]
+        }
+      } else if (bType === "thinking") {
+        return [{ type: "reasoning-end", id: `thinking-${index}` }]
+      }
       const block = toolBlocks.get(index)
       if (block) {
         toolBlocks.delete(index)

--- a/tests/provider-parity.test.ts
+++ b/tests/provider-parity.test.ts
@@ -1082,7 +1082,11 @@ run([
             setTimeout(() => reject(new Error("abort test: first part never arrived")), 5000),
           ),
         ])
-        assertEqual((first.value as { type?: string }).type, "text-delta")
+        assert(
+          (first.value as { type?: string }).type === "text-start" ||
+            (first.value as { type?: string }).type === "text-delta",
+          `expected text part, got ${(first.value as { type?: string }).type}`,
+        )
         controller.abort()
         const rest: Array<Record<string, unknown>> = []
         for (;;) {

--- a/tests/stream.test.ts
+++ b/tests/stream.test.ts
@@ -10,6 +10,8 @@ import {
   mapFinishReason,
   ccEventToStreamPart,
   ccUsageToAiSdkUsage,
+  createOpenAIStreamParser,
+  createAnthropicStreamParser,
 } from "../src/provider/stream.js"
 import { assert, assertEqual, rejects, run } from "./harness.js"
 
@@ -292,6 +294,121 @@ run([
     "unknown events are ignored",
     () => {
       assertEqual(ccEventToStreamPart({ type: "heartbeat" }), [])
+    },
+  ],
+
+  [
+    "createOpenAIStreamParser emits reasoning-start before reasoning-delta and reasoning-end before text or finish",
+    () => {
+      const parser = createOpenAIStreamParser()
+      const chunkId = "gen_01M0Q3F1FQQ0EV6CQZCZ9QFPB8"
+      const chunks = [
+        { id: chunkId, choices: [{ delta: { reasoning_content: "Thinking step 1" } }] },
+        { id: chunkId, choices: [{ delta: { reasoning_content: " and step 2" } }] },
+        { id: chunkId, choices: [{ delta: { content: "Final answer" } }] },
+        {
+          id: chunkId,
+          choices: [{ delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 20, completion_tokens: 15, total_tokens: 35 },
+        },
+      ]
+      const parts = chunks.flatMap((c) => parser(c))
+      const types = parts.map((p) => (p as { type: string }).type)
+      assertEqual(types, [
+        "reasoning-start",
+        "reasoning-delta",
+        "reasoning-delta",
+        "reasoning-end",
+        "text-start",
+        "text-delta",
+        "text-end",
+        "finish",
+      ])
+
+      const rStart = parts[0] as { type: string; id?: string }
+      assertEqual(rStart.id, chunkId)
+      const rDelta1 = parts[1] as { type: string; id?: string; delta?: string }
+      assertEqual(rDelta1.id, chunkId)
+      assertEqual(rDelta1.delta, "Thinking step 1")
+      const rDelta2 = parts[2] as { type: string; id?: string; delta?: string }
+      assertEqual(rDelta2.id, chunkId)
+      assertEqual(rDelta2.delta, " and step 2")
+      const rEnd = parts[3] as { type: string; id?: string }
+      assertEqual(rEnd.id, chunkId)
+
+      const tStart = parts[4] as { type: string; id?: string }
+      assertEqual(tStart.id, chunkId)
+      const tDelta = parts[5] as { type: string; id?: string; delta?: string }
+      assertEqual(tDelta.id, chunkId)
+      assertEqual(tDelta.delta, "Final answer")
+      const tEnd = parts[6] as { type: string; id?: string }
+      assertEqual(tEnd.id, chunkId)
+    },
+  ],
+
+  [
+    "createOpenAIStreamParser closes reasoning-end on finish when no text is emitted",
+    () => {
+      const parser = createOpenAIStreamParser()
+      const chunkId = "gen_reasoning_only"
+      const chunks = [
+        { id: chunkId, choices: [{ delta: { reasoning: "Thinking only" } }] },
+        {
+          id: chunkId,
+          choices: [{ delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 5 },
+        },
+      ]
+      const parts = chunks.flatMap((c) => parser(c))
+      const types = parts.map((p) => (p as { type: string }).type)
+      assertEqual(types, ["reasoning-start", "reasoning-delta", "reasoning-end", "finish"])
+      assertEqual((parts[0] as { id: string }).id, chunkId)
+      assertEqual((parts[2] as { id: string }).id, chunkId)
+    },
+  ],
+
+  [
+    "createAnthropicStreamParser handles thinking block lifecycle",
+    () => {
+      const parser = createAnthropicStreamParser()
+      const events = [
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "thinking_delta", thinking: "Pondering" },
+        },
+        { type: "content_block_stop", index: 0 },
+        { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+        { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Answer" } },
+        { type: "content_block_stop", index: 1 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      ]
+      const parts = events.flatMap((e) => parser(e))
+      const types = parts.map((p) => (p as { type: string }).type)
+      assertEqual(types, [
+        "reasoning-start",
+        "reasoning-delta",
+        "reasoning-end",
+        "text-start",
+        "text-delta",
+        "text-end",
+        "finish",
+      ])
+      assertEqual((parts[0] as { id: string }).id, "thinking-0")
+      assertEqual((parts[1] as { delta: string }).delta, "Pondering")
+      assertEqual((parts[2] as { id: string }).id, "thinking-0")
+      assertEqual((parts[3] as { id: string }).id, "text-1")
+      assertEqual((parts[4] as { delta: string }).delta, "Answer")
+      assertEqual((parts[5] as { id: string }).id, "text-1")
     },
   ],
 ])


### PR DESCRIPTION
Fixes https://github.com/rashidrazak/opencode-cmd-provider/issues/69

### Problem
When streaming from OpenAI-compatible (`/provider/v1/chat/completions`) or Anthropic (`/provider/v1/messages`) endpoints, models emitting reasoning (such as `deepseek/deepseek-v4-flash`) send chunk deltas without explicit start/end markers. OpenCode's stream consumer tracks active parts by ID and aborts if deltas arrive without a prior start event or without clean lifecycle boundaries, failing with:
- `"reasoning part <id> not found"`
- `"text part <id> not found"`

### Solution
- **OpenAI stream parser**: In `createOpenAIStreamParser` (`src/provider/stream.ts`), track reasoning and text states. Synthesize `{ type: "reasoning-start", id }` on the first reasoning delta, `{ type: "reasoning-end", id }` on conclusion, `{ type: "text-start", id }` on the first text delta, and `{ type: "text-end", id }` on conclusion.
- **Anthropic stream parser**: In `createAnthropicStreamParser` (`src/provider/stream.ts`), map `thinking` content blocks (`content_block_start`, `thinking_delta`, `content_block_stop`) to `reasoning-start`, `reasoning-delta`, and `reasoning-end`.
- **Testing**: Added unit tests in `tests/stream.test.ts` covering reasoning and text lifecycle events, and updated parity assertions in `tests/provider-parity.test.ts`. All test suites (`npm test`) pass cleanly.