### PR TITLE
chore(release): 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.5.1 - 2026-08-24
+
+Fix: provider parsers now synthesize the full reasoning and text lifecycle —
+`reasoning-start`/`reasoning-end` and `text-start`/`text-end` — for both
+OpenAI-style and Anthropic-style streams, so AI SDK consumers see balanced
+section boundaries instead of missing or duplicated end events.
+
+### Fixes
+
+- **OpenAI-style streams** now emit `reasoning-start` before the first
+  reasoning delta and `reasoning-end` before text, tool calls, or finish; the
+  same for `text-start`/`text-end`. Reasoning and text sections use stable ids
+  from the first chunk (instead of per-chunk ids), and unfinished sections are
+  closed when the stream finishes.
+- **Anthropic-style streams** now recognize `thinking` blocks and emit
+  `reasoning-start`/`reasoning-delta`/`reasoning-end` for them. `content_block_stop`
+  closes each block with the correct end event per its type (`text-end`,
+  `reasoning-end`, or `tool-input-end` + a single `tool-call`), replacing the
+  previous "emit both text-end and tool-input-end" pair that left consumers to
+  ignore the spurious one.
+- New `tests/stream.test.ts` cases cover the OpenAI reasoning→text ordering,
+  reasoning-only finishes, and the Anthropic thinking-block lifecycle;
+  `tests/provider-parity.test.ts` accepts `text-start` as the first text part.
+
 ## 1.5.0 - 2026-08-23
 
 Feature: the `[CMD] ` display-name prefix for auto-registered models is now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-cmd-provider",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/catalog/facts.ts
+++ b/src/catalog/facts.ts
@@ -8,7 +8,7 @@
 export const FACTS_SOURCE_URL = "https://unpkg.com/command-code@1.32.1/dist/bundled/command-code-knowledge/reference/models.md"
 export const MODALITIES_SOURCE_URL = "https://unpkg.com/command-code@1.32.1/dist/cli.mjs"
 export const FACTS_PACKAGE_VERSION = "1.32.1"
-export const FACTS_LAST_REFRESHED = "2026-08-23"
+export const FACTS_LAST_REFRESHED = "2026-08-24"
 
 export const MODEL_EFFORTS: Readonly<Record<string, readonly string[]>> = {
   "deepseek/deepseek-v4-pro": ["high","max"],

--- a/src/deals/catalog.ts
+++ b/src/deals/catalog.ts
@@ -113,5 +113,5 @@ export const PLAN_CATALOG: Readonly<Record<PlanId, PlanInfo>> = {
 }
 
 export const DEAL_SOURCE_URL = "https://commandcode.ai/docs/resources/pricing-limits"
-export const DEAL_LAST_REFRESHED = "2026-08-23"
+export const DEAL_LAST_REFRESHED = "2026-08-24"
 export const DEAL_PACKAGE_VERSION = "docs"


### PR DESCRIPTION
## Release 1.5.1

Bump version to 1.5.1 (patch) and add the CHANGELOG entry for PR #70.

### Included
- `package.json`: 1.5.0 → 1.5.1
- `package-lock.json`: version fields → 1.5.1
- `CHANGELOG.md`: `## 1.5.1 - 2026-08-24` — stream lifecycle fixes
- `src/catalog/facts.ts`, `src/deals/catalog.ts`: refreshed date stamps (2026-08-24)

Once merged, the v1.5.1 tag will be pushed to trigger the release pipeline.