### PR TITLE
fix(ci): build before testing in the catalog-refresh cron

### DIFF
--- a/.github/workflows/catalog-refresh.yml
+++ b/.github/workflows/catalog-refresh.yml
@@ -56,12 +56,13 @@ jobs:
           node-version: 22
           cache: npm
 
-      # bun is on PATH for consistency with CI/release — the TUI
-      # bundle (`scripts/build-tui.ts`) is bun-only (see AGENTS.md).
-      # The cron does not run `npm run build` today; bun is here so
-      # the workflow is self-contained when the maintainer chooses
-      # to add it later (e.g. once the pre-existing `dist/tui.js`
-      # test-isolation issue is resolved).
+      # bun is on PATH because the TUI bundle (`scripts/build-tui.ts`)
+      # is bun-only (see AGENTS.md). The cron builds before testing:
+      # `npm test` includes a contract test that asserts `npm pack`
+      # contains `dist/tui.js`, and a fresh checkout has no `dist/`
+      # (it is gitignored) — the "pre-existing dist/tui.js
+      # test-isolation failure" was exactly that: the cron never ran
+      # the build. Building also typechecks the regenerated catalogs.
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -83,11 +84,15 @@ jobs:
       - name: Regenerate catalogs
         run: npm run refresh
 
-      # The test suite is the next gate. A `dist/tui.js`-shaped
-      # failure here is the pre-existing test-isolation issue tracked
-      # in the handoff; the schedule is observed manually before
-      # auto-merge is enabled, so a flaky-looking test will be caught
-      # and triaged before the cron can ship a bad PR.
+      # Build (tsc + bun TUI bundle) before testing: the pack contract
+      # test needs dist/tui.js present, and typechecking the regenerated
+      # catalogs is a free extra gate.
+      - name: Build
+        run: npm run build
+
+      # The test suite is the next gate. The schedule is observed
+      # manually before auto-merge is enabled, so a flaky-looking test
+      # will be caught and triaged before the cron can ship a bad PR.
       - name: Run test suite
         run: npm test
 


### PR DESCRIPTION
The cron's `npm test` failed on the pack contract test (`npm pack must include dist/tui.js`) — on a fresh checkout `dist/` doesn't exist (gitignored), and the cron never ran `npm run build`. The "pre-existing dist/tui.js test-isolation failure" tracked in the handoff was this exact bug, misdiagnosed as environmental.

Fix: run `npm run build` (tsc + bun TUI bundle) after `npm run refresh` and before `npm test`. Bonus: the regenerated catalogs get typechecked as an extra gate. Comments updated to drop the stale "does not run build today" note.

Verified locally: this was the last failing step of the cron's test gate (all other tests pass on the refreshed tree); with the build step the same suite is green in CI (see ci.yml, which already builds first).