### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.6.0 - 2026-08-28
 
 ### Deals pipeline: RSC-primary + daily catalog refresh cron
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-cmd-provider",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release 1.6.0 — the RSC-primary deals pipeline + daily catalog refresh cron.

- Version bump `1.5.2 → 1.6.0` (`package.json` + `package-lock.json`; the lockfile was stale at 1.5.1).
- CHANGELOG: the `Unreleased` section becomes `## 1.6.0 - 2026-08-28` — this exact section becomes the GitHub Release body.
- Catalog freshness pre-verified: `npm run refresh` produced **zero diff** against main (command-code@1.37.0, fixtures and deals byte-identical), so the release pipeline's stale-catalog gate will pass.

After merge: tag `v1.6.0` on main → `release.yml` runs (build + tests, catalog drift gate, OIDC npm publish with provenance, GitHub Release).