### PR TITLE
fix(catalog): re-pin tencent/hy4-preview to EFFORTS_MODELS

### DIFF
--- a/src/catalog/facts.ts
+++ b/src/catalog/facts.ts
@@ -5,9 +5,9 @@
 // modalities parsed from its CLI bundle (dist/cli.mjs). Regenerate
 // with `npm run refresh:snapshot`.
 
-export const FACTS_SOURCE_URL = "https://unpkg.com/command-code@1.37.0/dist/bundled/command-code-knowledge/reference/models.md"
-export const MODALITIES_SOURCE_URL = "https://unpkg.com/command-code@1.37.0/dist/cli.mjs"
-export const FACTS_PACKAGE_VERSION = "1.37.0"
+export const FACTS_SOURCE_URL = "https://unpkg.com/command-code@1.38.1/dist/bundled/command-code-knowledge/reference/models.md"
+export const MODALITIES_SOURCE_URL = "https://unpkg.com/command-code@1.38.1/dist/cli.mjs"
+export const FACTS_PACKAGE_VERSION = "1.38.1"
 export const FACTS_LAST_REFRESHED = "2026-08-28"
 
 export const MODEL_EFFORTS: Readonly<Record<string, readonly string[]>> = {
@@ -20,6 +20,7 @@ export const MODEL_EFFORTS: Readonly<Record<string, readonly string[]>> = {
   "Qwen/Qwen3.8-Max": ["low","medium","xhigh"],
   "Qwen/Qwen3.8-27B": ["low","medium","xhigh"],
   "Qwen/Qwen3.8-Flash": ["low","medium","xhigh"],
+  "tencent/hy4-preview": ["low","medium","high"],
   "claude-sonnet-5": ["low","medium","high","xhigh","max"],
   "claude-sonnet-4-6": ["low","medium","high","xhigh","max"],
   "claude-fable-5": ["low","medium","high","xhigh","max"],

--- a/src/provider/reasoning.ts
+++ b/src/provider/reasoning.ts
@@ -44,8 +44,13 @@ export const REASONING_MODELS: ReadonlySet<string> = new Set([
   "poolside/laguna-s-2.1-free",
   "stepfun/Step-3.7-Flash",
   "tencent/hy3-paid",
-  // Live RSC caps.reasoning=true, models.md has no Efforts entry (2026-08-28).
-  "tencent/hy4-preview",
+  // tencent/hy4-preview is reasoning-capable with explicit efforts
+  // (models.md lists `low, medium, high` since command-code@1.38.0,
+  // 2026-08-28) — it belongs in MODEL_EFFORTS, not here. Keeping it here
+  // would leave a snapshot model classified in both REASONING_MODELS and
+  // MODEL_EFFORTS, which breaks the dedicated
+  // `tencent/hy4-preview is an efforts model` pin in
+  // tests/catalog-metadata.test.ts.
   "thinkingmachines/inkling",
   "thinkingmachines/inkling-small",
 ])

--- a/tests/catalog-metadata.test.ts
+++ b/tests/catalog-metadata.test.ts
@@ -75,6 +75,7 @@ const EFFORTS_MODELS = new Set([
   "google/gemini-3.5-flash-lite",
   "google/gemini-3.1-flash-lite",
   "sakana/fugu-ultra",
+  "tencent/hy4-preview",
   "xai/grok-4.5",
   "xai/grok-4.6",
 ])
@@ -194,14 +195,16 @@ run([
   ],
 
   [
-    "tencent/hy4-preview is reasoning-capable without variants",
+    "tencent/hy4-preview is an efforts model",
     () => {
-      // New upstream model (added 2026-08-28): live RSC caps.reasoning is
-      // true and models.md lists no Efforts entry, so it belongs in
-      // REASONING_MODELS with no MODEL_EFFORTS — mirrors the muse-spark
-      // classification above.
+      // Added 2026-08-28 (command-code@1.37.0): live RSC caps.reasoning=true
+      // with no explicit Efforts entry, classified as REASONING_MODELS.
+      // command-code@1.38.0 (same day) added `low, medium, high` to the
+      // Efforts column, so the model now belongs in MODEL_EFFORTS and must
+      // be removed from REASONING_MODELS. The "classified exactly once"
+      // gate above will fail if a model is in both.
       assertEqual(isReasoningModel("tencent/hy4-preview"), true)
-      assertEqual(MODEL_EFFORTS["tencent/hy4-preview"], undefined)
+      assertEqual(MODEL_EFFORTS["tencent/hy4-preview"], ["low", "medium", "high"])
     },
   ],
 


### PR DESCRIPTION
## Summary

Fixes the catalog-refresh cron failure ([run 33195360130](https://github.com/rashidrazak/opencode-cmd-provider/actions/runs/33195360130)) where the **Run test suite** step exited non-zero after regenerating the catalog.

### Root cause

Commit [cefd331](https://github.com/rashidrazak/opencode-cmd-provider/commit/cefd331) (the 1.37.0 catalog refresh, today) added `tencent/hy4-preview` to `REASONING_MODELS` and pinned it as "reasoning-capable without variants", based on the upstream `models.md` having no `Efforts` entry for it.

Hours later, upstream shipped `command-code@1.38.0` (now `1.38.1`) and the same day's cron picked it up — the `Efforts` column for that model now lists `low, medium, high`. The regenerated `MODEL_EFFORTS` therefore contains `["low","medium","high"]` for it, and the dedicated test pin fails:

```
FAIL - tencent/hy4-preview is reasoning-capable without variants:
  assertion: expected undefined, got ["low","medium","high"]
```

The "classified exactly once" gate at `tests/catalog-metadata.test.ts:168` did not catch the model being in both `REASONING_MODELS` and `MODEL_EFFORTS` simultaneously — it only inspects the three hand-maintained sets.

### Changes

1. **`src/provider/reasoning.ts`** — remove `tencent/hy4-preview` from `REASONING_MODELS`. The inline comment now records the upstream flip (`1.37.0` no-efforts → `1.38.0` `low,medium,high`).
2. **`tests/catalog-metadata.test.ts`** — add `tencent/hy4-preview` to `EFFORTS_MODELS` (so the "classified exactly once" gate now actively covers the move) and rewrite the specific test from "is reasoning-capable without variants" to "is an efforts model" asserting the live efforts list `["low", "medium", "high"]`.
3. **`src/catalog/facts.ts`** — regenerated to `command-code@1.38.1` via `npm run refresh:snapshot`. Net change: 30 → 31 effort entries; `tencent/hy4-preview: ["low","medium","high"]` is the only new row. All other effort entries and the 62 cost rows are unchanged.

### Verification

- `npm run typecheck` — clean.
- `npx tsx tests/catalog-metadata.test.ts` — all 10 cases pass, including the rewritten pin.
- `npx tsx tests/reasoning.test.ts` and `tests/plugin-models.test.ts` — clean.
- `npm run test:integration` (both files) — clean.
- `npx tsx tests/contract.test.ts` — all 8 cases pass.
- `npm run format:check` — clean.
- The catalog-refresh cron's next run will re-validate end-to-end (the regenerated facts will match what this PR already pins, so the test gate that failed in run 33195360130 will pass).

### Test plan

CI's `test` job (the same job the failed cron runs) is expected to pass on this PR. The cron's next run after merge should complete through the test step and open its own catalog-refresh PR as usual.