### PR TITLE
chore(release): 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ classification re-pin, and two CI fixes for the daily catalog-refresh cron.
   `Open PR` step's `gh pr list --head X` already copes correctly with a
   force-pushed tip. Locked down with
   `tests/catalog-refresh-push.test.ts`.
+- **Test fix for the push test** — `tests/catalog-refresh-push.test.ts`'s
+  verification `git ls-remote` previously ran from the outer project
+  CWD, so it resolved `origin` to GitHub rather than the test's local
+  bare remote. It passed only on the day the matching
+  `catalog-refresh/${date}` branch happened to exist on GitHub. Now
+  passes `-C repo.work` so the `origin` resolution is scoped to the
+  test fixture.
 
 ## 1.6.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 1.6.1 - 2026-08-29
+
+Patch release. Catalog refresh to `command-code@1.38.1`, one catalog
+classification re-pin, and two CI fixes for the daily catalog-refresh cron.
+
+- **Catalog refresh** — snapshot + capability facts + RSC fixtures refreshed
+  to `command-code@1.38.1` (was 1.37.0). Net: 30 → 31 effort entries;
+  `tencent/hy4-preview` is the new row (Efforts column now lists
+  `low, medium, high`, was empty in 1.37.0). The 62 cost rows are unchanged.
+  The deals catalog is unaffected (the new model already had its RSC
+  availability + deal info in 1.37.0 fixtures). A follow-up 2026-08-29 cron
+  re-captured the RSC fixtures and refreshed `src/catalog/facts.ts` to
+  upstream's new values.
+- **Catalog classification** — `tencent/hy4-preview` re-pinned to
+  `EFFORTS_MODELS` in `src/catalog/facts.ts`; the prior
+  `REASONING_MODELS` classification was a labelling error in 1.6.0 (upstream
+  advertises it as an effort-controlled model, not a reasoning model). The
+  matching unit-test pin was updated in lockstep.
+- **CI: catalog-refresh heredoc** — `realpath` the relative `.ts` path
+  before the `npx tsx -e` heredoc in `.github/workflows/catalog-refresh.yml`.
+  The `after` loop passed a bare-relative path (e.g. `src/catalog/snapshot.ts`)
+  to the heredoc, which Node's ESM resolver parsed as a package name and
+  rejected with `ERR_MODULE_NOT_FOUND`. The `before` loop was unaffected
+  because it used `/tmp/...` absolute paths. Locked down with
+  `tests/catalog-refresh-extract.test.ts`.
+- **CI: catalog-refresh push** — force-push the `catalog-refresh/${date}`
+  branch in `.github/workflows/catalog-refresh.yml`. Two consecutive cron
+  runs on the same day land sibling commits on `main`'s HEAD; `git push -u`
+  then rejects as non-fast-forward, leaving the cron stuck. `-fu` handles
+  both the partial-failure rerun and the fresh-branch case; the branch is
+  owned only by this workflow, so there's no clobber risk. The
+  `Open PR` step's `gh pr list --head X` already copes correctly with a
+  force-pushed tip. Locked down with
+  `tests/catalog-refresh-push.test.ts`.
+
 ## 1.6.0 - 2026-08-28
 
 ### Deals pipeline: RSC-primary + daily catalog refresh cron

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",

--- a/tests/catalog-refresh-push.test.ts
+++ b/tests/catalog-refresh-push.test.ts
@@ -112,8 +112,15 @@ run([
           true,
         )
         // The remote tip should now be the second commit, not the
-        // first. Verify by listing the remote ref.
+        // first. Verify by listing the remote ref. Pass `-C
+        // repo.work` so `origin` resolves to the test's local bare
+        // remote, not the outer project checkout's `origin` (which
+        // is GitHub) — without it, the test passed only on the day
+        // the matching `catalog-refresh/${date}` branch happened to
+        // exist on GitHub.
         const { stdout } = await exec("git", [
+          "-C",
+          repo.work,
           "ls-remote",
           "origin",
           "refs/heads/catalog-refresh/2026-08-29",


### PR DESCRIPTION
Patch release.

- Bump `package.json` to `1.6.1`.
- Add `## 1.6.1 - 2026-08-29` section to `CHANGELOG.md` (the same body the GitHub Release will use).

Contents since v1.6.0:
- Catalog refresh to `command-code@1.38.1` (`tencent/hy4-preview` added, 30 → 31 effort entries).
- Re-pin `tencent/hy4-preview` to `EFFORTS_MODELS` in `src/catalog/facts.ts`.
- Two CI fixes to `.github/workflows/catalog-refresh.yml` (realpath the `.ts` path; force-push the branch on rerun).
- 2026-08-29 cron re-capture of the RSC fixtures + facts refresh.

After this lands on `main`, tag `v1.6.1` and push the tag to trigger `release.yml`.