### PR TITLE
chore(release): 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,39 @@
-# Changelog
+## 1.6.3 - 2026-09-02
+
+### Model catalog
+
+## Model catalog
+
+- **FACTS_LAST_REFRESHED**: `2026-09-01` → `2026-09-01`
+
+No changes.
+
+### Reasoning classification
+
+## Reasoning classification
+
+- **CLASSIFICATION_LAST_REFRESHED**: `` → `2026-09-02`
+
+_first refresh — no classification data on the before side._
+
+### Deals intelligence
+
+## Deals intelligence
+
+- **DEAL_LAST_REFRESHED**: `2026-09-01` → `2026-09-01`
+
+No changes.
+
+### Full changeset
+
+The generated-catalog diff above is only the data layer (the new classification module — first refresh). This PR carries the whole derived-classification implementation (#109–#116): the shared RSC record source (scripts/rsc-source.mjs), the classification generator in the refresh ladder, the derived runtime (src/provider/reasoning.ts), the semantic diff sections + classificationChanged boolean, the meaningful-change drift detection (date-only churn opens no PR), ADR-0006/0007 + glossary + docs, and the auto-release workflow. npm test green on the head commit; per-ticket summary in the commit trail.
+
+### Maintainer actions before merge (ADR-0007)
+
+1. Add the RELEASE_PUSH_TOKEN secret (fine-grained PAT, this repo only, Contents: Read and write) so the tag push triggers the release pipeline — a default-token push does not start other workflows.
+2. Branch protection is currently off, so the bot push lands freely; when you enable it, add a bypass for the pushing identity (ruleset bypass list).
+
+_Opened from `catalog-refresh/2026-09-02` so merging exercises the new merge-to-release path: the auto-release workflow cuts `chore(release): 1.6.3` + tags v1.6.3, and release.yml publishes._
 
 ## 1.6.2 - 2026-09-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-cmd-provider",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release 1.6.3

Lands the auto-release's bot-authored bump commit on `main` so the existing `v1.6.3` tag points at a commit that is on `main` (the release pipeline's `on-main` assertion requires this).

- `package.json` / `package-lock.json`: version 1.6.2 → **1.6.3** (lockfile synced via npm, never hand-edited)
- `CHANGELOG.md`: new `## 1.6.3 - 2026-09-02` section, authored from PR #117's semantic sections by `scripts/release-notes.mjs` (Model catalog: no changes · Reasoning classification: first refresh — derived classification shipped · Deals intelligence: no changes)

### Context

Merging #117 fired the new auto-release workflow (ADR-0007). The bump commit and tag were cut correctly, but the `main` push was rejected by the repository rulesets because of a credential-override bug in the workflow (the checkout-persisted default token overrode `RELEASE_PUSH_TOKEN`; fixed in 6756789, pending on `catalog-refresh/2026-09-02`). The tag `v1.6.3` therefore points at a commit that is not yet on `main`.

**After this PR merges (use a merge commit so the tag's commit becomes an ancestor of `main`), the repair completes:** delete and re-push the `v1.6.3` tag → the tag-driven release pipeline runs: build, full suite, stale-catalog gates, npm publish with provenance, GitHub Release from the CHANGELOG section.

Contents of the release itself: the derived reasoning classification pipeline (#109–#116) — see #117 for the full changeset.

**Merge method: Create a merge commit** (required — squashing would put a *different* commit on `main` than the one the tag points at).