### PR TITLE
fix(ci): harden the auto-release pipeline after first live run

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -52,6 +52,14 @@ jobs:
           # on-main assertion passes unchanged.
           ref: main
           fetch-depth: 0
+          # Do NOT persist the default token's credential. checkout writes
+          # an `http.https://github.com/.extraheader` for github.com that
+          # OVERRIDES the URL-embedded RELEASE_PUSH_TOKEN in the push step
+          # below — the push then runs as github-actions[bot], which no
+          # ruleset bypass-lists (run 33683416448 failed exactly this way:
+          # the tag landed, the main push was rule-rejected, and the
+          # default-token tag push could not trigger release.yml).
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -114,6 +122,9 @@ jobs:
         run: |
           set -euo pipefail
           next="$(node -p "require('./package.json').version")"
+          # Defensive: drop any inherited github.com credential header so
+          # the URL-embedded token below is authoritative for the push.
+          git config --unset-all http.https://github.com/.extraheader 2>/dev/null || true
           git remote set-url origin "https://x-access-token:${GH_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push -q origin main "v${next}"
           echo "auto-release: cut v${next} on main; the tag-driven release pipeline takes it from here."

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -25,6 +25,18 @@
  * Renders the `## X.Y.Z - date` CHANGELOG section from a merged refresh
  * PR body's semantic sections.
  *
+ * Section parsing details that matter:
+ *   - The cron's PR body embeds `diff-catalog.mjs` output INSIDE its
+ *     `###` sections, and that output carries `##` H2 headings ("## Model
+ *     catalog"). An H2 line inside a section is therefore CONTENT, not a
+ *     terminator — treating it as one emptied every section (run of
+ *     PR #117: the emitted CHANGELOG failed `format:check` because the
+ *     emptied sections left doubled blank lines). Sections end at the
+ *     next `###` heading or at the `---` footer separator only.
+ *   - The output must be Prettier-stable: never more than one consecutive
+ *     blank line (the release pipeline's `format:check` runs over the
+ *     committed CHANGELOG).
+ *
  * @param {{ version: string, date: string, prBody: string }} args
  * @returns {string}
  */
@@ -39,33 +51,70 @@ export function buildChangelogSection({ version, date, prBody }) {
       continue
     }
     if (current === null) continue
-    // A section ends at the next heading of any level or at the `---`
-    // footer separator — anything after the separator is the bot footer.
-    if (/^##\s/.test(line) || /^---/.test(line)) {
+    // A section ends at the next `###` heading or at the `---` footer
+    // separator — anything after the separator is the bot footer.
+    // `##` lines are content (the embedded diff sections use them).
+    if (/^###\s/.test(line) || /^---/.test(line)) {
       current = null
       continue
     }
     current.lines.push(line)
   }
   const semantic = sections.filter((section) => section.title.toLowerCase() !== "changed files")
-  const out = [`## ${version} - ${date}`, ""]
+  const out = [`## ${version} - ${date}`]
   if (semantic.length === 0) {
     // The PR body is untrusted and may not carry the expected sections;
     // the release still ships with a minimal, honest entry.
-    out.push("Automated catalog refresh.", "")
-    return out.join("\n")
+    out.push("", "Automated catalog refresh.", "")
+    return collapseBlankLines(out)
   }
   for (const section of semantic) {
-    out.push(`### ${section.title}`)
-    out.push("")
+    out.push("", `### ${section.title}`)
     // Trim trailing blank lines per section so the join is deterministic
     // regardless of upstream spacing churn.
     const body = [...section.lines]
     while (body.length > 0 && body[body.length - 1].trim() === "") body.pop()
     for (const line of body) out.push(line)
-    out.push("")
   }
-  return out.join("\n")
+  out.push("")
+  return collapseBlankLines(out)
+}
+
+/**
+ * Collapses runs of blank lines to a single blank line, strips
+ * leading/trailing blanks, and separates list blocks from following
+ * paragraph lines. Prettier does the same to Markdown (a non-list line
+ * directly after a list item is a lazy continuation and gets re-indented),
+ * so the emitted CHANGELOG must already be in that normal form or the
+ * release pipeline's `format:check` fails on the bump commit.
+ *
+ * @param {string[]} lines
+ * @returns {string}
+ */
+function collapseBlankLines(lines) {
+  const out = []
+  const isListItem = (line) => /^\s*(?:[-*+]|\d+[.)])\s/.test(line)
+  for (const line of lines) {
+    if (line.trim() === "") {
+      if (out.length === 0 || out[out.length - 1] === "") continue
+      out.push("")
+      continue
+    }
+    // A paragraph line right after a list item is a lazy continuation in
+    // Markdown — Prettier re-indents it, so break it out with a blank line.
+    if (
+      out.length > 0 &&
+      isListItem(out[out.length - 1]) &&
+      !isListItem(line) &&
+      !line.startsWith("#") &&
+      !line.startsWith("```")
+    ) {
+      out.push("")
+    }
+    out.push(line)
+  }
+  while (out.length > 0 && out[out.length - 1] === "") out.pop()
+  return out.join("\n") + "\n"
 }
 
 async function main() {

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -308,6 +308,19 @@ run([
       assert(workflow.includes("skip-release"), workflow)
       // Concurrency-serialized (safety rail).
       assert(workflow.includes("concurrency:"), workflow)
+      // The checkout must NOT persist the default token credential: it
+      // would override the push token (run 33683416448 failed exactly
+      // this way — push ran as github-actions[bot] and was rule-rejected).
+      assert(
+        workflow.includes("persist-credentials: false"),
+        "checkout must set persist-credentials: false so the push uses RELEASE_PUSH_TOKEN",
+      )
+      // The push step must clear any inherited credential header before
+      // rewriting the remote URL (defence in depth).
+      assert(
+        workflow.includes("git config --unset-all http.https://github.com/.extraheader"),
+        "the push step must clear the inherited extraheader before pushing",
+      )
       // The tag-existence rail must gate the PUSH step too — a full skip
       // means no commit, no tag, and no push.
       assert(


### PR DESCRIPTION
Two defects the first live auto-release (v1.6.3, #117 → #118) exposed, cherry-picked from the release branch:

1. **Credential override** (`924f37f`): `actions/checkout` persists the default `GITHUB_TOKEN` as `http.https://github.com/.extraheader`, which overrode the URL-embedded `RELEASE_PUSH_TOKEN` — the bump push ran as `github-actions[bot]`, which no ruleset bypass-lists, so `main` was rejected (the tag landed because rulesets govern `refs/heads/main` only) and the recursive-event rule meant `release.yml` never fired. Fix: `persist-credentials: false` + defensive extraheader unset; both locked in the guards test.

2. **CHANGELOG emitter stability** (`06dec53`): `buildChangelogSection` treated embedded `##` headings (the cron's PR body embeds diff output) as section terminators, emptying sections and leaving doubled blank lines → `format:check` failed on the bump commit; and a non-list line after a list item is a lazy continuation Prettier re-indents. Fix: sections end at `###`/`---` only; emit list→paragraph separators; output is now byte-stable under Prettier (verified against #117's real body).

Also includes the rulesets correction for ADR-0007/RELEASE.md (`90fd383` + `ee66478`): protection is via rulesets, `main-review` already bypasses the maintainer, `main-hard-rules` required-test check is what the pusher bypass must cover.

No runtime behavior change; suite green on the head commit.