### PR TITLE
fix(release): leave one blank line before the concatenated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 | `meta/muse-spark-1.2-contributor` | classification | reasoning-without-efforts | efforts model (low, medium, high, xhigh) |
 | `meta/muse-spark-1.3`             | classification | reasoning-without-efforts | efforts model (low, medium, high, xhigh) |
 | `meta/muse-spark-1.3-contributor` | classification | reasoning-without-efforts | efforts model (low, medium, high, xhigh) |
+
 ## 1.6.3 - 2026-09-02
 
 ### Model catalog

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -95,7 +95,6 @@ export function buildChangelogSection({ version, date, prBody }) {
   out.push("")
   return collapseBlankLines(out)
 }
-
 /**
  * Collapses runs of blank lines to a single blank line, strips
  * leading/trailing blanks, and separates list blocks from following
@@ -135,7 +134,15 @@ function collapseBlankLines(lines) {
     }
     out.push(line)
   }
-  while (out.length > 0 && out[out.length - 1] === "") out.pop()
+  // The workflow concatenates this output directly against the existing
+  // CHANGELOG (`{ cat release-notes.md; cat CHANGELOG.md; }`), so a section
+  // ending in a table would land flush against the next `## X.Y.Z` heading
+  // — Prettier requires a blank line between a table and a following
+  // heading and the release pipeline's format:check fails on the bump
+  // commit (the v1.6.4 release run). End the output with a single trailing
+  // blank line: `join` ends the last content line with \n, so one extra \n
+  // yields exactly one empty line, and Prettier normalizes away any surplus
+  // if the existing CHANGELOG also leads with blanks.
   return out.join("\n") + "\n"
 }
 

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -240,6 +240,40 @@ run([
     },
   ],
   [
+    "buildChangelogSection: output is Prettier-stable after CHANGELOG concatenation",
+    () => {
+      // The workflow concatenates the emitted section against the existing
+      // CHANGELOG (`{ cat release-notes.md; cat CHANGELOG.md; }`). A section
+      // ending in a table must leave exactly one blank line before the
+      // next `## X.Y.Z` heading, or format:check fails on the bump commit
+      // (the v1.6.4 release run). This locks the concatenation shape, not
+      // just the standalone emitter output.
+      const section = buildChangelogSection({
+        version: "1.6.4",
+        date: "2026-09-03",
+        prBody: PR_BODY,
+      })
+      const previous = ["## 1.6.3 - 2026-09-02", "", "- previous release."].join("\n")
+      const concatenated = section + previous
+      const lines = concatenated.split("\n")
+      const nextHeading = lines.findIndex((line, i) => i > 0 && line.startsWith("## 1.6.3"))
+      assert(nextHeading > 0, "the previous section heading must be present")
+      assertEqual(
+        lines[nextHeading - 1],
+        "",
+        "exactly one blank line must separate the emitted section from the next heading",
+      )
+      // And the whole concatenation must be a fixed point of Prettier's
+      // normal form: no doubled blanks anywhere.
+      for (let i = 1; i < lines.length; i++) {
+        assert(
+          !(lines[i] === "" && lines[i - 1] === ""),
+          `doubled blank line at concatenated line ${i + 1}`,
+        )
+      }
+    },
+  ],
+  [
     "release fragment: merging a refresh PR cuts the bot-authored patch release",
     async () => {
       const repo = await setupRepo()


### PR DESCRIPTION
## Summary

The v1.6.4 auto-release chain worked end to end (refresh PR merged, bump commit cut, tag pushed) but the release pipeline's format:check rejected the emitted CHANGELOG: the new section ends in a table, and the workflow concatenates it flush against the next `## 1.6.3` heading. Prettier requires a blank line between a table and a following heading. npm publish never ran (it is downstream of format:check), so 1.6.4 is unreleased.

## The fix

`buildChangelogSection` ends its output with a single trailing blank line, so the `{ cat release-notes.md; cat CHANGELOG.md; }` concatenation lands in Prettier's normal form. The committed CHANGELOG.md is normalized too, clearing CI on main.

The failure was a verification gap, not a renderer bug: the emitter's Prettier-stability was tested standalone, but the defect only appears after concatenation with the previous CHANGELOG. The new regression test locks the concatenation shape (exactly one blank before the next heading, no doubled blanks) and was verified against PR rashidrazak/opencode-cmd-provider#121's real body — the exact production input.

## Ship path

After merge: re-run the auto-release for 1.6.4. The tag `v1.6.4` already exists, so the release needs the CHANGELOG fix on main and a re-tag (delete and re-push the tag, or manually re-run the pipeline per ADR-0007's manual-trigger fallback).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/Pi_Coding_Agent-6366f1?logo=data:image/svg%2Bxml&logoColor=white)