### PR TITLE
fix(release): stop the changelog extractor at version headings only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,16 @@ jobs:
         run: |
           version="$(node -p "require('./package.json').version")"
           pattern="$(printf '%s' "$version" | sed 's/\./\\./g')"
+          # Only a version-shaped heading (`## X.Y.Z - date`) terminates the
+          # section. The catalog-refresh sections legitimately embed `##`
+          # H2 headings from diff-catalog.mjs output ("## Model catalog",
+          # "## Deals intelligence"); treating any `##` as a terminator
+          # truncated the v1.6.3 and v1.6.4 GitHub Release notes to the
+          # first heading, dropping the change tables the notes exist to
+          # carry. This awk fragment is locked by tests/auto-release.test.ts.
           awk -v re="^## ${pattern} - " '
             $0 ~ re { found = 1 }
-            found && $0 ~ /^## / && $0 !~ re { exit }
+            found && $0 ~ /^## [0-9]+\.[0-9]+\.[0-9]+ - / && $0 !~ re { exit }
             found { print }
           ' CHANGELOG.md > /tmp/release-notes.md
           if [ -s /tmp/release-notes.md ]; then

--- a/tests/replay-verification.test.ts
+++ b/tests/replay-verification.test.ts
@@ -739,6 +739,12 @@ run([
         assert(release.includes('tags: ["v*"]'), release)
         assert(release.includes("npm publish"), release)
         assert(release.includes("stale catalog snapshot or facts"), release)
+        // The release pipeline's changelog extractor must only stop at a
+        // version-shaped heading — the refresh sections embed `## Model
+        // catalog` H2s, and treating any `##` as a terminator truncated
+        // the v1.6.3/v1.6.4 release notes to the first heading (both runs
+        // shipped 5-line notes with no change tables).
+        assert(release.includes("/^## [0-9]+\\.[0-9]+\\.[0-9]+ - /"), release)
       } finally {
         await rm(base, { recursive: true, force: true })
       }


### PR DESCRIPTION
## Summary

The re-tagged v1.6.4 release succeeded (npm at 1.6.4, pipeline green), but the GitHub Release body shipped as 5 lines: `### Model catalog` and nothing else. The pipeline's changelog extractor treats any `##` heading as the section terminator, and the catalog-refresh sections legitimately embed `## Model catalog` / `## Deals intelligence` H2s from diff-catalog output, so extraction stopped at the first one and dropped every change table.

This is also the true root cause of the original "v1.6.3 release note only says Model catalog" report — the same truncation, before the table work existed.

## The fix

The extractor in `release.yml` terminates only on a version-shaped heading (`## X.Y.Z - date`). Verified against the real v1.6.4 CHANGELOG: the extracted section grows from 4 to 30 lines and carries all 10 muse-spark table rows. The awk fragment is locked by the replay test, which previously asserted the release pipeline was untouched and now locks this seam too.

## After merge

One-time fixup of the published v1.6.4 release body (the npm artifact is correct and unaffected):

```bash
gh release edit v1.6.4 --notes-file <(git show v1.6.4:CHANGELOG.md | awk '/^## 1\.6\.4 - /{f=1} f&&/^## [0-9]+\.[0-9]+\.[0-9]+ - /&&!/1\.6\.4/{exit} f')
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/Pi_Coding_Agent-6366f1?logo=data:image/svg%2Bxml&logoColor=white)