### PR TITLE
fix(refresh): drop facts rows for models outside the API snapshot

### DIFF
--- a/scripts/refresh-snapshot.mjs
+++ b/scripts/refresh-snapshot.mjs
@@ -211,6 +211,26 @@ if (missingModalities.length > 0) {
 const modalities = Object.fromEntries(
   Object.entries(parsedModalities.modalities).filter(([id]) => snapshotIds.has(id)),
 )
+// models.md can run ahead of the API (a row for a model the catalog
+// endpoint doesn't serve yet — or anymore). Facts for non-snapshot ids
+// would break the catalog-metadata suite (facts ⊆ snapshot), so drop
+// them here — the same filtering the modalities already get above. The
+// reverse direction (a snapshot model with no facts row) stays loud via
+// that suite's per-model cost coverage check.
+const droppedFacts = Object.keys(costs).filter((id) => !snapshotIds.has(id))
+if (droppedFacts.length > 0) {
+  console.log(
+    `refresh-snapshot: dropping ${droppedFacts.length} facts not in the API snapshot: ${droppedFacts.join(", ")}`,
+  )
+}
+const snapshotEfforts = Object.fromEntries(
+  Object.entries(efforts).filter(([id]) => snapshotIds.has(id)),
+)
+const snapshotCosts = Object.fromEntries(
+  Object.entries(costs).filter(([id]) => snapshotIds.has(id)),
+)
+if (Object.keys(snapshotCosts).length === 0)
+  fail("Command Code catalog facts contain no cost rows for the snapshot models")
 
 await mkdir(dirname(out), { recursive: true })
 await writeFile(out, renderSnapshot(models), "utf-8")
@@ -222,12 +242,12 @@ await writeFile(
     modalitiesSourceUrl: modalitiesUrl,
     packageVersion: latest,
     lastRefreshed: new Date().toISOString().split("T")[0],
-    efforts,
-    costs,
+    efforts: snapshotEfforts,
+    costs: snapshotCosts,
     modalities,
   }),
   "utf-8",
 )
 console.log(
-  `refresh-snapshot: wrote facts (${Object.keys(efforts).length} efforts, ${Object.keys(costs).length} costs) for command-code@${latest} to ${factsOut}`,
+  `refresh-snapshot: wrote facts (${Object.keys(snapshotEfforts).length} efforts, ${Object.keys(snapshotCosts).length} costs) for command-code@${latest} to ${factsOut}`,
 )

--- a/tests/refresh-snapshot.test.ts
+++ b/tests/refresh-snapshot.test.ts
@@ -135,6 +135,69 @@ run([
   ],
 
   [
+    "refresh-snapshot drops facts rows for models outside the API snapshot",
+    async () => {
+      // Upstream skew (run 33922321678): the npm models.md carried a
+      // gpt-6-astra row the catalog endpoint no longer served, and the
+      // unfiltered facts broke the catalog-metadata suite (facts ⊆
+      // snapshot). Facts for non-snapshot ids must be dropped, loudly.
+      const dir = await mkdtemp(join(tmpdir(), "cc-facts-ahead-"))
+      const out = join(dir, "snapshot.ts")
+      const factsOut = join(dir, "facts.ts")
+      const aheadMd =
+        "## Open Source\n\n" +
+        "| Id | Name | Context | Efforts | $/1M in/out · cache read | Min plan | Best for |\n" +
+        "|---|---|---|---|---|---|---|\n" +
+        "| `claude-sonnet-5` | Claude Sonnet 5 | 1M | low, medium, high, xhigh, max | $2/$10 · cache $0.2 (write $2.5) | Pro and above | best |\n" +
+        "| `gpt-6-astra` | GPT 6 Astra | 1M | low, medium, high | $1/$2 · cache $0.1 | Pro and above | best |\n"
+      const mock = await startMockCc({
+        models: {
+          object: "list",
+          data: [{ id: "claude-sonnet-5", name: "Claude Sonnet 5", context_length: 200000 }],
+        },
+        registry: { "dist-tags": { latest: "1.28.1" } },
+        factsMd: aheadMd,
+        modalitiesBundle:
+          'const models={SONNET:{name:"Claude Sonnet 5",id:"claude-sonnet-5",inputModalities:["text","image"],contextWindow:2e5},' +
+          'ASTRA:{name:"GPT 6 Astra",id:"gpt-6-astra",inputModalities:["text"],contextWindow:1e6}}',
+      })
+      try {
+        const result = await runScript(
+          ["scripts/refresh-snapshot.mjs", "--out", out, "--facts-out", factsOut],
+          {
+            ...process.env,
+            COMMANDCODE_API_BASE: mock.url,
+            COMMANDCODE_REGISTRY_URL: `${mock.url}/registry`,
+            COMMANDCODE_FACTS_URL: `${mock.url}/models.md`,
+            COMMANDCODE_MODALITIES_URL: `${mock.url}/cli.mjs`,
+          },
+        )
+        assert(result.status === 0, result.stderr || result.stdout)
+        assert(
+          result.stdout.includes("gpt-6-astra"),
+          `expected the dropped model to be named in stdout, got: ${result.stdout}`,
+        )
+        const mod = await import(factsOut)
+        // Object-equality style (as in the facts test above): the ahead
+        // row must be absent from every map while the snapshot row is kept
+        // with its parsed values.
+        assertEqual(mod.MODEL_COSTS, {
+          "claude-sonnet-5": { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+        })
+        assertEqual(mod.MODEL_EFFORTS, {
+          "claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
+        })
+        assertEqual(mod.MODEL_INPUT_MODALITIES, {
+          "claude-sonnet-5": ["text", "image"],
+        })
+      } finally {
+        await mock.close()
+        await rm(dir, { recursive: true, force: true })
+      }
+    },
+  ],
+
+  [
     "refresh-snapshot fails loudly when the registry body is not JSON",
     async () => {
       const dir = await mkdtemp(join(tmpdir(), "cc-registry-parse-"))


### PR DESCRIPTION
Fixes the catalog-refresh failure on run 33922321678.

**Root cause:** upstream skew — the API catalog serves 67 models but `command-code@1.49.0`'s bundled `models.md` lists 68 rows, including `gpt-6-astra` (new in 1.49.0, published <1h before the cron ran; the live docs already carry it, so the API is lagging the release, not a retirement). `refresh-snapshot.mjs` wrote all 68 rows into `facts.ts` unfiltered, and the catalog-metadata suite's `MODEL_COSTS has no stale entries outside the snapshot` check failed the run.

**Fix:** filter parsed efforts/costs to snapshot ids before writing `facts.ts` — the same filtering modalities already get — logging dropped ids loudly. The reverse direction (snapshot model with no facts row) stays loud via the per-model cost coverage check, since a servable model with missing metadata is user-facing harm.

**Verification:**
- New regression test (`refresh-snapshot drops facts rows for models outside the API snapshot`) green
- Live dry-run to a temp dir against the exact upstream state that broke the cron: 67 snapshot, 67 costs, 41 efforts, zero stale entries
- Full `npm test`: exit 0, 439 ok, zero failures; `npm run build`, `format:check`, `git diff --check` clean