### PR TITLE
chore(release): 1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.7.5 - 2026-09-12
 
 Fix: the runtime provider is pinned to the plugin's own version
 ([#152](https://github.com/rashidrazak/opencode-cmd-provider/issues/152),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-cmd-provider",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cmd-provider",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Command Code provider + plugin for opencode",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release ritual for **1.7.5** (patch) — the version-pinned Provider specifier fix from #152/#153.

- `package.json` → `1.7.5`
- `package-lock.json` synced by npm (`--package-lock-only`), both `version` lines at 1.7.5
- `CHANGELOG.md`: `## Unreleased` promoted to `## 1.7.5 - 2026-09-12`; this section becomes the GitHub Release body

Catalog freshness pre-checked locally: `npm run refresh:snapshot` produced only the `FACTS_LAST_REFRESHED` date line (ignored by the release gate), so the pipeline's stale-catalog gate should pass with no refresh needed.

Once merged, I'll tag `v1.7.5` on the merge commit, which triggers `release.yml` (build + full suite + catalog gates + OIDC npm publish + GitHub Release).